### PR TITLE
swagger 세팅 및 공통 응답 예외처리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,8 @@ out/
 *.sock
 
 
+# config server 보안 프로퍼티
 /application/config/src/main/resources/config-server.properties
+
+# application data
+/application/yabam/data

--- a/application/gateway/build.gradle
+++ b/application/gateway/build.gradle
@@ -14,4 +14,7 @@ dependencies {
 
     // spring cloud config
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.4.0'
 }

--- a/application/gateway/src/main/java/com/gateway/GatewayApplication.java
+++ b/application/gateway/src/main/java/com/gateway/GatewayApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
-@EnableDiscoveryClient  // Discovery Client를 사용하기 위한 어노테이션
 public class GatewayApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(GatewayApplication.class, args);

--- a/application/gateway/src/main/resources/application.yml
+++ b/application/gateway/src/main/resources/application.yml
@@ -3,3 +3,12 @@ spring:
     name: gateway
   config:
     import: configserver:http://localhost:8087
+
+
+springdoc:
+  swagger-ui:
+    path: /docs
+    urls:
+      - name: Yabam API
+        url: http://localhost:8072/yabam/v3/api-docs
+

--- a/application/yabam/build.gradle
+++ b/application/yabam/build.gradle
@@ -15,9 +15,7 @@ dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    // lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+
 
     // config client
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
@@ -28,4 +26,10 @@ dependencies {
 
     // discovery client module
     implementation(project(':common:discovery-client'))
+
+    // common
+    implementation(project(':common:base'))
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 }

--- a/application/yabam/src/main/java/com/application/YabamApplication.java
+++ b/application/yabam/src/main/java/com/application/YabamApplication.java
@@ -1,8 +1,7 @@
-package com.application.festival.yabam;
+package com.application;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
 public class YabamApplication {

--- a/application/yabam/src/main/java/com/application/config/swagger/ApiErrorResponseExplanation.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/ApiErrorResponseExplanation.java
@@ -1,0 +1,14 @@
+package com.application.config.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.exception.ErrorCode;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponseExplanation {
+	ErrorCode errorCode();
+}

--- a/application/yabam/src/main/java/com/application/config/swagger/ApiErrorResponseHandler.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/ApiErrorResponseHandler.java
@@ -1,0 +1,114 @@
+package com.application.config.swagger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import com.exception.ErrorCode;
+import com.response.FailedResponseBody;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.Builder;
+import lombok.Getter;
+
+@Component
+@Profile("!test && !prod")
+public class ApiErrorResponseHandler {
+
+	public void handleApiErrorResponse(Operation operation, HandlerMethod handlerMethod) {
+		ApiResponseExplanations apiResponseExplanations
+			= handlerMethod.getMethodAnnotation(ApiResponseExplanations.class);
+
+		if (apiResponseExplanations != null) {
+			generateResponseCodeResponseExample(operation, Arrays.asList(apiResponseExplanations.errors()));
+		}
+	}
+
+	private void generateResponseCodeResponseExample(Operation operation,
+		List<ApiErrorResponseExplanation> apiErrorResponseExamples) {
+		ApiResponses responses = operation.getResponses();
+
+		Map<Integer, List<ExampleHolder>> statusWithExampleHolders = apiErrorResponseExamples.stream()
+			.map(this::createExampleHolder)
+			.collect(Collectors.groupingBy(ExampleHolder::getHttpStatusCode));
+
+		addExamplesToResponses(responses, statusWithExampleHolders);
+	}
+
+	private ExampleHolder createExampleHolder(ApiErrorResponseExplanation apiErrorResponseExample) {
+		ErrorCode errorCode = apiErrorResponseExample.errorCode();
+		return ExampleHolder.builder()
+			.httpStatusCode(errorCode.getStatus().value()) // HTTP 상태 코드
+			.name(errorCode.name()) // enum 이름
+			.errorCode(errorCode.getCode()) // 커스텀 에러 코드
+			.description(errorCode.getMessage()) // 에러 메시지
+			.holder(createSwaggerExample(errorCode, errorCode.getMessage()))
+			.build();
+	}
+
+	private Example createSwaggerExample(ErrorCode errorCode, String description) {
+		FailedResponseBody failedResponseBody
+			= new FailedResponseBody(errorCode.getCode(), errorCode.getMessage());
+		ExampleFailedResponseBody failedResponseBodyExample = new ExampleFailedResponseBody("false", failedResponseBody);
+
+		Example example = new Example();
+		example.setValue(failedResponseBodyExample);
+		example.setDescription(description); // 설명을 예제에 추가
+
+		return example;
+	}
+
+	private void addExamplesToResponses(
+		ApiResponses responses,
+		Map<Integer, List<ExampleHolder>> statusWithExampleHolders
+	) {
+		statusWithExampleHolders.forEach((status, exampleHolders) -> {
+			Content content = new Content();
+			MediaType mediaType = new MediaType();
+			ApiResponse apiResponse = new ApiResponse();
+
+			exampleHolders.forEach(
+				exampleHolder -> mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder())
+			);
+
+			content.addMediaType("application/json", mediaType);
+			apiResponse.setContent(content);
+			responses.addApiResponse(String.valueOf(status), apiResponse);
+		});
+	}
+
+	@Getter
+	@Builder
+	public static class ExampleHolder {
+		private final int httpStatusCode;
+		private final String name;
+		private final String errorCode;
+		private final String description;
+		private final Example holder;
+	}
+
+	@Getter
+	public static class ExampleFailedResponseBody {
+		private  final String success;
+		private  final String code;
+		private  final String message;
+
+		public ExampleFailedResponseBody(String success , FailedResponseBody failedResponseBody) {
+			this.success = success;
+			this.code = failedResponseBody.getCode();
+			this.message = failedResponseBody.getMsg();
+		}
+
+	}
+
+}

--- a/application/yabam/src/main/java/com/application/config/swagger/ApiResponseExplanations.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/ApiResponseExplanations.java
@@ -1,0 +1,17 @@
+package com.application.config.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiResponseExplanations {
+
+	ApiSuccessResponseExplanation success() default @ApiSuccessResponseExplanation();
+
+	ApiErrorResponseExplanation[] errors() default {};
+}
+

--- a/application/yabam/src/main/java/com/application/config/swagger/ApiSuccessResponseExplanation.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/ApiSuccessResponseExplanation.java
@@ -1,0 +1,22 @@
+package com.application.config.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.http.HttpStatus;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiSuccessResponseExplanation {
+	HttpStatus status() default HttpStatus.OK;
+
+	Class<?> responseClass() default EmptyClass.class;
+
+	String description() default "";
+
+	class EmptyClass {
+	}
+}
+

--- a/application/yabam/src/main/java/com/application/config/swagger/ApiSuccessResponseHandler.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/ApiSuccessResponseHandler.java
@@ -1,0 +1,63 @@
+package com.application.config.swagger;
+
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+@Component
+@Profile("!test && !prod")
+public class ApiSuccessResponseHandler {
+
+	private static final String APPLICATION_JSON = "application/json";
+	private static final String IS_SUCCESS = "true";
+
+	public void handleApiSuccessResponse(Operation operation, HandlerMethod handlerMethod) {
+		// ApiResponseExplanations 어노테이션을 읽어옴
+		ApiResponseExplanations apiResponseExplanations
+			= handlerMethod.getMethodAnnotation(ApiResponseExplanations.class);
+
+		// 어노테이션이 없다면 반환
+		if (apiResponseExplanations == null) {
+			return;
+		}
+
+		// 성공 응답 설명을 가져옴
+		ApiSuccessResponseExplanation apiSuccessResponseExplanation = apiResponseExplanations.success();
+
+		if (apiSuccessResponseExplanation != null) {
+			ApiResponses responses = operation.getResponses();
+			// 기본 200 OK 응답이 있다면 제거
+			responses.remove("200");
+
+			// 성공 response 구성
+			Schema<?> responseSchema = new Schema<>()
+				.addProperty("success",
+					new Schema<>().type("string").example(IS_SUCCESS))
+				.addProperty("data",
+					apiSuccessResponseExplanation.responseClass()
+						.isAssignableFrom(ApiSuccessResponseExplanation.EmptyClass.class)
+						? new Schema<>().type("object")
+						: new Schema<>().$ref(
+						"#/components/schemas/" + apiSuccessResponseExplanation.responseClass().getSimpleName())
+				);
+
+			// ApiResponse를 만들어 operation의 응답에 추가
+			ApiResponse apiResponse = new ApiResponse()
+				.description(apiSuccessResponseExplanation.description())
+				.content(new Content()
+					.addMediaType(APPLICATION_JSON, new MediaType().schema(responseSchema))
+				);
+
+			// 성공 응답을 상태 코드에 맞게 추가 (예: 200)
+			responses.addApiResponse(String.valueOf(apiSuccessResponseExplanation.status().value()), apiResponse);
+		}
+	}
+}

--- a/application/yabam/src/main/java/com/application/config/swagger/SwaggerConfig.java
+++ b/application/yabam/src/main/java/com/application/config/swagger/SwaggerConfig.java
@@ -1,0 +1,104 @@
+package com.application.config.swagger;
+
+
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+import org.springframework.web.method.HandlerMethod;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@OpenAPIDefinition(
+	info = @Info(
+		title = "yabam API",
+		version = "v1",
+		description = "yabam API 입니다."
+	)
+)
+@Profile(value = {"local", "dev"})
+public class SwaggerConfig {
+	private static final String JWT = "JWT";
+	private final Environment environment;
+	private final ApiSuccessResponseHandler apiSuccessResponseHandler;
+	private final ApiErrorResponseHandler apiErrorResponseHandler;
+
+	@Bean
+	public OpenAPI openApi() {
+		String activeProfile = "";
+		if (!ObjectUtils.isEmpty(environment.getActiveProfiles()) && environment.getActiveProfiles().length >= 1) {
+			activeProfile = environment.getActiveProfiles()[0];
+		}
+
+		String serverUrl = environment.getProperty("swagger.server-url");
+		String serverDescription = environment.getProperty("swagger.description");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList(JWT);
+		return new OpenAPI()
+			.info(apiInfo(activeProfile))
+			.addServersItem(
+				new io.swagger.v3.oas.models.servers.Server()
+					.url(serverUrl)
+					.description(serverDescription)
+			)
+			.addSecurityItem(securityRequirement)
+			.components(securitySchemes());
+	}
+
+	@Bean
+	ForwardedHeaderFilter forwardedHeaderFilter() {
+		return new ForwardedHeaderFilter();
+	}
+
+	@Bean
+	public OperationCustomizer customize() {
+		return (Operation operation, HandlerMethod handlerMethod) -> {
+			apiSuccessResponseHandler.handleApiSuccessResponse(operation, handlerMethod);
+			apiErrorResponseHandler.handleApiErrorResponse(operation, handlerMethod);
+			return operation;
+		};
+	}
+
+	private Components securitySchemes() {
+		final SecurityScheme accessTokenSecurityScheme = new SecurityScheme()
+			.name(JWT)
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("Bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+
+		return new Components()
+			.addSecuritySchemes(JWT, accessTokenSecurityScheme);
+	}
+
+	private io.swagger.v3.oas.models.info.Info apiInfo(String activeProfile) {
+		return new io.swagger.v3.oas.models.info.Info()
+			.title("백엔드 API 명세서 (" + activeProfile + ")")
+			.description(
+				"<p>이 문서는 KumohTalk 백엔드 API의 사용 방법과 예시를 제공합니다. "
+					+
+					"API에 대한 보다 자세한 설명은 <a href=\"https://kyxxn.notion.site/39d4878d23dd439da70c7c4dc33a8a1c?pvs=4\" target='_blank'>API 개요</a>를 참고해 주세요.</p>"
+					+
+					"<p>API 사용 중 문제가 발생하거나 추가 문의가 필요한 경우, 담당자에게 문의해 주세요.</p>"
+					+
+					"<p>API 명세의 예외 상황은 도메인에 대한 에러가 명시되어 있습니다. field Validation 에러는 명시되어 있지않고 4XX 에러로 반환하게 됩니다</p>"
+					+
+					"<p>5XX 에러는 정의되지 않은 서버 에러이므로 해당 담당자 혹은 디스코드로 문의해 주세요</p>"
+			)
+			.version("v1.0.0");
+	}
+
+}

--- a/application/yabam/src/main/resources/application.yml
+++ b/application/yabam/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
       on-profile: local
     import: configserver:http://localhost:8087
 
+swagger:
+  server-url: http://localhost:8072 # gateway 주소
+  description: "local 백엔드 서버"
 ---
 
 spring:

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,9 @@ subprojects {
 	apply plugin: 'io.spring.dependency-management'
 
 	dependencies {
-
+		// lombok
+		compileOnly 'org.projectlombok:lombok'
+		annotationProcessor 'org.projectlombok:lombok'
 	}
 
 	tasks.named('test') {

--- a/common/base/build.gradle
+++ b/common/base/build.gradle
@@ -1,0 +1,13 @@
+bootJar{
+    enabled = false
+}
+jar{
+    enabled = true
+}
+
+dependencies {
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
+
+    compileOnly 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+
+}

--- a/common/base/src/main/java/com/config/GlobalExceptionHandlerAutoConfiguration.java
+++ b/common/base/src/main/java/com/config/GlobalExceptionHandlerAutoConfiguration.java
@@ -1,0 +1,14 @@
+package com.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.exception.handler.GlobalExceptionHandler;
+
+@AutoConfiguration
+public class GlobalExceptionHandlerAutoConfiguration {
+	@Bean
+	public GlobalExceptionHandler globalExceptionHandler() {
+		return new GlobalExceptionHandler();
+	}
+}

--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+	TEST_ERROR(HttpStatus.BAD_GATEWAY, "TEST_0001","멀티 모듈 환경에서 에러 핸들링 테스트" ), // TODO : 곧 삭제 될 예정
+	;
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+
+	ErrorCode(HttpStatus status, String code, String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/common/base/src/main/java/com/exception/ServiceException.java
+++ b/common/base/src/main/java/com/exception/ServiceException.java
@@ -1,0 +1,13 @@
+package com.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ServiceException extends RuntimeException{
+	private final ErrorCode errorCode;
+
+	public ServiceException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/common/base/src/main/java/com/exception/handler/GlobalExceptionHandler.java
+++ b/common/base/src/main/java/com/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.exception.handler;
+
+import static com.response.ResponseUtil.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+import com.response.ResponseBody;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+@Hidden
+public class GlobalExceptionHandler {
+	@ExceptionHandler(ServiceException.class) // custom 에러
+	public ResponseEntity<ResponseBody<Void>> handleServiceException(HttpServletRequest request, ServiceException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		return ResponseEntity.status(errorCode.getStatus())
+			.body(createFailureResponse(errorCode));
+	}
+}

--- a/common/base/src/main/java/com/response/FailedResponseBody.java
+++ b/common/base/src/main/java/com/response/FailedResponseBody.java
@@ -1,0 +1,17 @@
+package com.response;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Getter;
+
+@Getter
+@JsonTypeName("false")
+public final class FailedResponseBody extends ResponseBody<Void> {
+
+    private final String msg;
+
+    public FailedResponseBody(String code, String msg) {
+        this.setCode(code);
+        this.msg = msg;
+    }
+}

--- a/common/base/src/main/java/com/response/ResponseBody.java
+++ b/common/base/src/main/java/com/response/ResponseBody.java
@@ -1,0 +1,28 @@
+package com.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "success")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SuccessResponseBody.class, name = "true"),
+        @JsonSubTypes.Type(value = FailedResponseBody.class, name = "false")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public sealed abstract class ResponseBody<T> permits SuccessResponseBody, FailedResponseBody {
+    private String code;
+}

--- a/common/base/src/main/java/com/response/ResponseUtil.java
+++ b/common/base/src/main/java/com/response/ResponseUtil.java
@@ -1,0 +1,28 @@
+package com.response;
+
+import com.exception.ErrorCode;
+
+public class ResponseUtil {
+
+	public static ResponseBody<Void> createSuccessResponse() {
+		return new SuccessResponseBody<>();
+	}
+
+	public static <T> ResponseBody<T> createSuccessResponse(T data) {
+		return new SuccessResponseBody<>(data);
+	}
+
+	public static ResponseBody<Void> createFailureResponse(ErrorCode errorCode) {
+		return new FailedResponseBody(
+			errorCode.getCode(),
+			errorCode.getMessage()
+		);
+	}
+
+	public static ResponseBody<Void> createFailureResponse(ErrorCode errorCode, String customMessage) {
+		return new FailedResponseBody(
+			errorCode.getCode(),
+			customMessage
+		);
+	}
+}

--- a/common/base/src/main/java/com/response/SuccessResponseBody.java
+++ b/common/base/src/main/java/com/response/SuccessResponseBody.java
@@ -1,0 +1,19 @@
+package com.response;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import lombok.Getter;
+
+@Getter
+@JsonTypeName("true")
+public final class SuccessResponseBody<T> extends ResponseBody<T> {
+    private final T data;
+
+    public SuccessResponseBody() {
+        data = null;
+    }
+
+    public SuccessResponseBody(T result) {
+        this.data = result;
+    }
+}

--- a/common/base/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/base/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.config.GlobalExceptionHandlerAutoConfiguration

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,4 @@ include(':application:gateway')
 
 // common
 include(":common:discovery-client")
+include(":common:base")


### PR DESCRIPTION

## 🍀 구현 내용

#### 1️⃣  swagger 적용
- gateway 에서 docs를 라우팅하게 세팅

#### 2️⃣ 공통 응답 및 도메인 예외 커스텀 및 핸들러 구현

- 기존 금오톡 서비스와 동일하게 구현했습니다