### PR TITLE
OIDC 소셜 로그인 및 회원가입 기능 개발 (구글, 카카오, 애플)

### DIFF
--- a/.github/workflows/domain-ci.yml
+++ b/.github/workflows/domain-ci.yml
@@ -2,9 +2,12 @@ name: CI - Domain Only
 
 on:
   push:
+    branches: [ "main" ]
     paths:
       - 'domain/**'
+
   pull_request:
+    branches: [ "main" ]
     paths:
       - 'domain/**'
 

--- a/.github/workflows/domain-ci.yml
+++ b/.github/workflows/domain-ci.yml
@@ -1,0 +1,30 @@
+name: CI - Domain Only
+
+on:
+  push:
+    paths:
+      - 'domain/**'
+  pull_request:
+    paths:
+      - 'domain/**'
+
+jobs:
+  domain-ci:
+    name: Build & Test domain-pos module
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build and Test domain module
+        run: ./gradlew :domain:domain-pos:clean :domain:domain-pos:build --no-daemon

--- a/application/auth/build.gradle
+++ b/application/auth/build.gradle
@@ -1,0 +1,25 @@
+bootJar {
+    enabled = true
+}
+
+jar {
+    enabled = false
+}
+
+dependencies {
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // security
+    /* JWT */
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    /* Feign */
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+
+    // common exception
+    implementation project(":common:base")
+}

--- a/application/auth/src/main/java/com/auth/AuthApplication.java
+++ b/application/auth/src/main/java/com/auth/AuthApplication.java
@@ -1,0 +1,17 @@
+package com.auth;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableFeignClients
+public class AuthApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AuthApplication.class, args);
+	}
+
+}

--- a/application/auth/src/main/java/com/auth/domain/entity/OidcPayload.java
+++ b/application/auth/src/main/java/com/auth/domain/entity/OidcPayload.java
@@ -1,0 +1,12 @@
+package com.auth.domain.entity;
+
+public record OidcPayload(
+	/* issuer */
+	String iss,
+	/* client id */
+	String aud,
+	/* aouth provider account unique id */
+	String sub,
+	String email
+) {
+}

--- a/application/auth/src/main/java/com/auth/domain/implement/JwtOidcProvider.java
+++ b/application/auth/src/main/java/com/auth/domain/implement/JwtOidcProvider.java
@@ -1,0 +1,131 @@
+package com.auth.domain.implement;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import com.auth.domain.entity.OidcPayload;
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtOidcProvider {
+	private static final String KID = "kid";
+	private static final String RSA = "RSA";
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * ID Token의 header 에서 KID 값을 추출하는 메서드
+	 */
+	public String getKidFromUnsignedTokenHeader(String token, String iss, String sub, String aud, String nonce) {
+		return getUnsignedTokenClaims(token, iss, sub, aud, nonce).get("header").get(KID);
+	}
+
+	/**
+	 * ID Token의 body를 추출하는 메서드
+	 */
+	public OidcPayload getOidcTokenBody(String token, String modulus, String exponent) {
+		Claims body = getOidcTokenJws(token, modulus, exponent).getPayload();
+		String aud = body.getAudience().iterator().next(); // aud가 여러개일 경우 첫 번째 aud를 사용
+
+		return new OidcPayload(
+			body.getIssuer(),
+			aud,
+			body.getSubject(),
+			body.get("email", String.class));
+	}
+
+	/**
+	 * ID Token의 header 와 payload 만 추출하는 메서드
+	 */
+	private String getUnsignedToken(String token) {
+		String[] splitToken = token.split("\\.");
+		if (splitToken.length != 3) {
+			throw new ServiceException(ErrorCode.INVALID_ID_TOKEN);
+		}
+		return splitToken[0] + "." + splitToken[1] + ".";
+	}
+
+	/**
+	 * ID Token의 header와 body를 Base64 방식으로 디코딩
+	 * 페이로드의 iss 값이 소셜 링크와 일치하는지 확인
+	 * 페이로드의 aud 값이 서비스 앱 키와 일치하는지 확인
+	 * 페이로드의 nonce 값이 소셜 로그인 요청 시 전달한 값과 일치하는지 확인
+	 */
+	private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String sub, String aud,
+		String nonce) {
+		try {
+			Base64.Decoder decoder = Base64.getUrlDecoder();
+
+			String unsignedToken = getUnsignedToken(token);
+			String headerJson = new String(decoder.decode(unsignedToken.split("\\.")[0]));
+			String payloadJson = new String(decoder.decode(unsignedToken.split("\\.")[1]));
+
+			Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
+			Map<String, String> payload = objectMapper.readValue(payloadJson, Map.class);
+
+			Assert.isTrue(payload.get("iss").equals(iss),
+				"iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
+			Assert.isTrue(payload.get("sub").equals(sub),
+				"sub is not matched. expected : " + sub + ", actual : " + payload.get("sub"));
+			Assert.isTrue(payload.get("aud").equals(aud),
+				"aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
+
+			return Map.of("header", header, "payload", payload);
+		} catch (IllegalArgumentException e) {
+			throw new ServiceException(ErrorCode.INVALID_ID_TOKEN);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * n과 e 의 조합으로 공개키를 생성하고 ID Token을 검증하는 메서드
+	 */
+	private Jws<Claims> getOidcTokenJws(String token, String modulus, String exponent) {
+		try {
+			return Jwts.parser()
+				.verifyWith(getRsaPublicKey(modulus, exponent))
+				.build()
+				.parseSignedClaims(token);
+		} catch (JwtException e) {
+			throw new ServiceException(ErrorCode.INVALID_ID_TOKEN);
+		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+			throw new ServiceException(ErrorCode.ABNORMAL_ID_TOKEN);
+		}
+	}
+
+	/**
+	 * 공개된 n, e 조합으로 공개키를 생성하는 메서드
+	 */
+	private PublicKey getRsaPublicKey(String modulus, String exponent) throws
+		NoSuchAlgorithmException,
+		InvalidKeySpecException {
+		KeyFactory keyFactory = KeyFactory.getInstance(RSA);
+		byte[] decodeN = Base64.getUrlDecoder().decode(modulus);
+		byte[] decodeE = Base64.getUrlDecoder().decode(exponent);
+		BigInteger nPublicKey = new BigInteger(1, decodeN);
+		BigInteger ePublicKey = new BigInteger(1, decodeE);
+
+		RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(nPublicKey, ePublicKey);
+		return keyFactory.generatePublic(publicKeySpec);
+	}
+}
+

--- a/application/auth/src/main/java/com/auth/domain/implement/OAuthOidcHelper.java
+++ b/application/auth/src/main/java/com/auth/domain/implement/OAuthOidcHelper.java
@@ -1,0 +1,81 @@
+package com.auth.domain.implement;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.auth.domain.entity.OidcPayload;
+import com.auth.domain.vo.OidcProvider;
+import com.auth.infra.oidc.client.OidcClient;
+import com.auth.infra.oidc.client.apple.AppleOidcClient;
+import com.auth.infra.oidc.client.google.GoogleOidcClient;
+import com.auth.infra.oidc.client.kakao.KakaoOidcClient;
+import com.auth.infra.oidc.dto.OidcPublicKey;
+import com.auth.infra.oidc.property.OidcClientProperties;
+import com.auth.infra.oidc.property.apple.AppleOidcProperties;
+import com.auth.infra.oidc.property.google.GoogleOidcProperties;
+import com.auth.infra.oidc.property.kakao.KakaoOidcProperties;
+import com.auth.infra.oidc.response.OidcPublicKeyResponse;
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+@Component
+public class OAuthOidcHelper {
+	private final JwtOidcProvider jwtOidcProvider;
+	private final Map<OidcProvider, Map<OidcClient, OidcClientProperties>> oauthOidcClients;
+
+	public OAuthOidcHelper(
+		JwtOidcProvider jwtOidcProvider,
+		KakaoOidcClient kakaoOidcClient,
+		GoogleOidcClient googleOidcClient,
+		AppleOidcClient appleOidcClient,
+		KakaoOidcProperties kakaoOidcProperties,
+		GoogleOidcProperties googleOidcProperties,
+		AppleOidcProperties appleOidcProperties
+	) {
+		this.jwtOidcProvider = jwtOidcProvider;
+		this.oauthOidcClients = Map.of(
+			OidcProvider.KAKAO, Map.of(kakaoOidcClient, kakaoOidcProperties),
+			OidcProvider.GOOGLE, Map.of(googleOidcClient, googleOidcProperties),
+			OidcProvider.APPLE, Map.of(appleOidcClient, appleOidcProperties)
+		);
+	}
+
+	/**
+	 * Provider에 따라 Client와 Properties를 선택하고 Odic public key 정보를 가져와서 ID Token의 payload를 추출하는 메서드
+	 *
+	 * @param provider : {@link OidcProvider}
+	 * @param oauthId  : Provider에서 발급한 사용자 식별자
+	 * @param idToken  : idToken
+	 * @param nonce    : 인증 서버 로그인 요청 시 전달한 임의의 문자열
+	 * @return OIDCDecodePayload : ID Token의 payload
+	 */
+	public OidcPayload getPayload(OidcProvider provider, String oauthId, String idToken, String nonce) {
+		OidcClient client = oauthOidcClients.get(provider).keySet().iterator().next();
+		OidcClientProperties properties = oauthOidcClients.get(provider).values().iterator().next();
+		OidcPublicKeyResponse response = client.getOidcPublicKey();
+		return getPayloadFromIdToken(idToken, properties.getIssuer(), oauthId, properties.getSecret(), nonce, response);
+	}
+
+	/**
+	 * ID Token의 payload를 추출하는 메서드 <br/>
+	 * OAuth 2.0 spec에 따라 ID Token의 유효성 검사 수행 <br/>
+	 *
+	 * @param idToken  : idToken
+	 * @param iss      : ID Token을 발급한 provider의 URL
+	 * @param sub      : ID Token의 subject (사용자 식별자)
+	 * @param aud      : ID Token이 발급된 앱의 앱 키
+	 * @param nonce    : 인증 서버 로그인 요청 시 전달한 임의의 문자열
+	 * @param response : 공개키 목록
+	 * @return OidcPayload : ID Token의 payload
+	 */
+	private OidcPayload getPayloadFromIdToken(String idToken, String iss, String sub, String aud, String nonce,
+		OidcPublicKeyResponse response) {
+		String kid = jwtOidcProvider.getKidFromUnsignedTokenHeader(idToken, iss, sub, aud, nonce);
+		OidcPublicKey key = response.getKeys().stream()
+			.filter(k -> k.kid().equals(kid))
+			.findFirst()
+			.orElseThrow(() -> new ServiceException(ErrorCode.NOT_MATCHED_PUBLIC_KEY));
+		return jwtOidcProvider.getOidcTokenBody(idToken, key.n(), key.e());
+	}
+}

--- a/application/auth/src/main/java/com/auth/domain/service/OidcService.java
+++ b/application/auth/src/main/java/com/auth/domain/service/OidcService.java
@@ -1,0 +1,10 @@
+package com.auth.domain.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OidcService {
+}

--- a/application/auth/src/main/java/com/auth/domain/vo/OidcProvider.java
+++ b/application/auth/src/main/java/com/auth/domain/vo/OidcProvider.java
@@ -1,0 +1,20 @@
+package com.auth.domain.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OidcProvider {
+	KAKAO,
+	GOOGLE,
+	APPLE;
+
+	@JsonCreator
+	public OidcProvider fromString(String type) { //TODO : validator 적용 해야함
+		return valueOf(type.toUpperCase());
+	}
+
+}

--- a/application/auth/src/main/java/com/auth/global/config/FeginConfig.java
+++ b/application/auth/src/main/java/com/auth/global/config/FeginConfig.java
@@ -1,0 +1,7 @@
+package com.auth.global.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@EnableFeignClients
+public class FeginConfig {
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/client/OidcClient.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/client/OidcClient.java
@@ -1,0 +1,7 @@
+package com.auth.infra.oidc.client;
+
+import com.auth.infra.oidc.response.OidcPublicKeyResponse;
+
+public interface OidcClient {
+	OidcPublicKeyResponse getOidcPublicKey();
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/client/apple/AppleOidcClient.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/client/apple/AppleOidcClient.java
@@ -1,0 +1,18 @@
+package com.auth.infra.oidc.client.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.auth.infra.oidc.client.OidcClient;
+import com.auth.infra.oidc.response.OidcPublicKeyResponse;
+
+@FeignClient(
+	name = "AppleOidcClient",
+	url = "${oauth2.client.provider.apple.jwks-uri}",
+	qualifiers = "appleOidcClient"
+)
+public interface AppleOidcClient extends OidcClient {
+	@Override
+	@GetMapping("/auth/keys")
+	OidcPublicKeyResponse getOidcPublicKey();
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/client/google/GoogleOidcClient.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/client/google/GoogleOidcClient.java
@@ -1,0 +1,18 @@
+package com.auth.infra.oidc.client.google;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.auth.infra.oidc.client.OidcClient;
+import com.auth.infra.oidc.response.OidcPublicKeyResponse;
+
+@FeignClient(
+	name = "GoogleOidcClient",
+	url = "${oauth2.client.provider.google.jwks-uri}",
+	qualifiers = "googleOidcClient"
+)
+public interface GoogleOidcClient extends OidcClient {
+	@Override
+	@GetMapping("/oauth2/v3/certs")
+	OidcPublicKeyResponse getOidcPublicKey();
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/client/kakao/KakaoOidcClient.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/client/kakao/KakaoOidcClient.java
@@ -1,0 +1,18 @@
+package com.auth.infra.oidc.client.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.auth.infra.oidc.client.OidcClient;
+import com.auth.infra.oidc.response.OidcPublicKeyResponse;
+
+@FeignClient(
+	name = "KakaoOidcClient",
+	url = "${oauth2.client.provider.kakao.jwks-uri}",
+	qualifiers = "kakaoOidcClient"
+)
+public interface KakaoOidcClient extends OidcClient {
+	@Override
+	@GetMapping("/.well-known/jwks.json")
+	OidcPublicKeyResponse getOidcPublicKey();
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/dto/OidcPublicKey.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/dto/OidcPublicKey.java
@@ -1,0 +1,11 @@
+package com.auth.infra.oidc.dto;
+
+public record OidcPublicKey(
+	String kid,
+	String kty,
+	String alg,
+	String use,
+	String n,
+	String e
+) {
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/property/OidcClientProperties.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/property/OidcClientProperties.java
@@ -1,0 +1,9 @@
+package com.auth.infra.oidc.property;
+
+public interface OidcClientProperties {
+	String getJwksUri();
+
+	String getSecret();
+
+	String getIssuer();
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/property/apple/AppleOidcProperties.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/property/apple/AppleOidcProperties.java
@@ -1,0 +1,22 @@
+package com.auth.infra.oidc.property.apple;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.auth.infra.oidc.property.OidcClientProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "oauth2.client.provider.apple")
+public class AppleOidcProperties implements OidcClientProperties {
+	private final String jwksUri;
+	private final String secret;
+
+	@Override
+	public String getIssuer() {
+		return jwksUri;
+	}
+}
+

--- a/application/auth/src/main/java/com/auth/infra/oidc/property/google/GoogleOidcProperties.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/property/google/GoogleOidcProperties.java
@@ -1,0 +1,17 @@
+package com.auth.infra.oidc.property.google;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.auth.infra.oidc.property.OidcClientProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "oauth2.client.provider.google")
+public class GoogleOidcProperties implements OidcClientProperties {
+	private final String jwksUri;
+	private final String secret;
+	private final String issuer;
+}

--- a/application/auth/src/main/java/com/auth/infra/oidc/property/kakao/KakaoOidcProperties.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/property/kakao/KakaoOidcProperties.java
@@ -1,0 +1,22 @@
+package com.auth.infra.oidc.property.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.auth.infra.oidc.property.OidcClientProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "oauth2.client.provider.kakao")
+public class KakaoOidcProperties implements OidcClientProperties {
+	private final String jwksUri;
+	private final String secret;
+
+	@Override
+	public String getIssuer() {
+		return jwksUri;
+	}
+}
+

--- a/application/auth/src/main/java/com/auth/infra/oidc/response/OidcPublicKeyResponse.java
+++ b/application/auth/src/main/java/com/auth/infra/oidc/response/OidcPublicKeyResponse.java
@@ -1,0 +1,14 @@
+package com.auth.infra.oidc.response;
+
+import java.util.List;
+
+import com.auth.infra.oidc.dto.OidcPublicKey;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OidcPublicKeyResponse {
+	List<OidcPublicKey> keys;
+}

--- a/application/auth/src/main/java/com/auth/presentation/controller/AuthController.java
+++ b/application/auth/src/main/java/com/auth/presentation/controller/AuthController.java
@@ -1,0 +1,13 @@
+package com.auth.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+}

--- a/application/auth/src/main/resources/application.yml
+++ b/application/auth/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+oauth2:
+  client:
+    provider:
+      apple:
+        jwks-uri: mock
+        secret: mock_secret
+      google:
+        jwks-uri: https://www.googleapis.com
+        secret: googleSecret
+        issuer: https://accounts.google.com
+      kakao:
+        jwks-uri: mock
+        secret: mock_secret

--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -11,7 +11,12 @@ public enum ErrorCode {
 
 	// Store
 	NOT_EQUAL_STORE_OWNER(HttpStatus.CONFLICT, "STORE_0001", "해당 가게의 점주가 아닙니다"),
-	NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "STORE_0002", "해당 가게를 찾을 수 없습니다");
+	NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "STORE_0002", "해당 가게를 찾을 수 없습니다"),
+
+	// Auth
+	INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0001", "해당 ID 토큰은 유효하지 않습니다."),
+	ABNORMAL_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0002", "해당 ID 토큰은 정상적이지 않습니다"),
+	NOT_MATCHED_PUBLIC_KEY(HttpStatus.NOT_FOUND, "AUTH_0003", "해당 ID 토큰의 공개키를 찾을 수 없습니다");
 
 	private final HttpStatus status;
 	private final String code;

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
@@ -10,19 +10,24 @@ public class StoreInfo {
 	private final Point2D.Double location;
 	private final String desciption;
 	private final String headImageUrl;
+	private final String university;
 
-	private StoreInfo(String storeName, Point2D.Double location, String desciption, String headImageUrl) {
+	private StoreInfo(String storeName, Point2D.Double location, String desciption, String headImageUrl,
+		String university) {
 		this.storeName = storeName;
 		this.location = location;
 		this.desciption = desciption;
 		this.headImageUrl = headImageUrl;
+		this.university = university;
 	}
 
-	public static StoreInfo of(String storeName, Point2D.Double location, String desciption, String headImageUrl) {
+	public static StoreInfo of(String storeName, Point2D.Double location, String desciption, String headImageUrl,
+		String university) {
 		return new StoreInfo(
 			storeName,
 			location,
 			desciption,
-			headImageUrl);
+			headImageUrl,
+			university);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
@@ -1,9 +1,28 @@
 package domain.pos.store.entity;
 
+import java.awt.geom.Point2D;
+
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class StoreInfo {
+	private final String storeName;
+	private final Point2D.Double location;
+	private final String desciption;
+	private final String headImageUrl;
+
+	private StoreInfo(String storeName, Point2D.Double location, String desciption, String headImageUrl) {
+		this.storeName = storeName;
+		this.location = location;
+		this.desciption = desciption;
+		this.headImageUrl = headImageUrl;
+	}
+
+	public static StoreInfo of(String storeName, Point2D.Double location, String desciption, String headImageUrl) {
+		return new StoreInfo(
+			storeName,
+			location,
+			desciption,
+			headImageUrl);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -30,10 +30,12 @@ public class StoreService {
 			});
 
 		final Long savedStoreId = storeWriter.createStore(owner, createRequestStoreInfo);
+		log.info("가게 생성 성공 : ownerId={}, storeId={}", ownerId, savedStoreId);
 		return savedStoreId;
 	}
 
 	public Store findStore(final Long storeId) {
+		log.info("가게 조회: storeId={}", storeId);
 		return storeReader.readSingleStore(storeId)
 			.orElseThrow(() -> {
 				log.warn("가게 조회 실패: storeId={}", storeId);
@@ -57,11 +59,15 @@ public class StoreService {
 			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
 		}
 
-		return storeWriter
+		Store updatedStore = storeWriter
 			.updateStoreInfo(previousStore, requestChangeStoreInfo);
+		log.info("가게 정보 수정 성공 : ownerId={}, storeId={}", ownerId, queryStoreId);
+
+		return updatedStore;
 	}
 
-	private static boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
+	// 가게 소유자와 요청 점주가 같은지 확인
+	private boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
 		return !previousStore.getStoreOwner().getOwnerId().equals(ownerId);
 	}
 
@@ -81,5 +87,6 @@ public class StoreService {
 			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
 		}
 		storeWriter.deleteStore(previousStore);
+		log.info("가게 삭제 성공 : ownerId={}, storeId={}", ownerId, storeId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -47,6 +47,11 @@ public class StoreService {
 		final Long ownerId,
 		final Long queryStoreId,
 		final StoreInfo requestChangeStoreInfo) {
+		ownerReader.findOwner(ownerId)
+			.orElseThrow(() -> {
+				log.warn("점주 조회 실패: ownerId={}", ownerId);
+				throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
+			});
 
 		final Store previousStore = storeReader.readSingleStore(queryStoreId)
 			.orElseThrow(() -> {
@@ -72,7 +77,7 @@ public class StoreService {
 	}
 
 	public void deleteStore(Long ownerId, Long storeId) {
-		Owner owner = ownerReader.findOwner(ownerId)
+		ownerReader.findOwner(ownerId)
 			.orElseThrow(() -> {
 				log.warn("점주 조회 실패: ownerId={}", ownerId);
 				throw new ServiceException(ErrorCode.NOT_VALID_OWNER);

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
@@ -2,6 +2,7 @@ package domain.pos.store.service;
 
 import static fixtures.member.OwnerFixture.*;
 import static fixtures.store.StoreFixture.*;
+import static fixtures.store.StoreInfoFixture.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.Mockito.*;
 
@@ -46,7 +47,7 @@ class StoreServiceTest extends ServiceTest {
 		@Test
 		void 성공() {
 			// given
-			StoreInfo requestStoreInfo = CREATE_REQUEST_STORE_INFO();
+			StoreInfo requestStoreInfo = GENERAL_STORE_INFO();
 			Long ownerId = GENERAL_OWNER().getOwnerId();
 			Owner savedOwner = GENERAL_OWNER();
 
@@ -71,7 +72,7 @@ class StoreServiceTest extends ServiceTest {
 		@Test
 		void 실패_점주_유효성검사() {
 			// given
-			StoreInfo requestStoreInfo = CREATE_REQUEST_STORE_INFO();
+			StoreInfo requestStoreInfo = GENERAL_STORE_INFO();
 			Owner savedOwner = GENERAL_OWNER();
 
 			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
@@ -141,11 +141,15 @@ class StoreServiceTest extends ServiceTest {
 		@Test
 		void 성공() {
 			// given
+			Owner savedOwner = GENERAL_OWNER();
+			Long queryOwnerId = savedOwner.getOwnerId();
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 			Store nonChangedStore = GENERAL_STORE();
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 			Store changedStore = CHANGED_GENERAL_STORE();
 
+			doReturn(Optional.of(savedOwner))
+				.when(ownerReader).findOwner(queryOwnerId);
 			doReturn(Optional.of(nonChangedStore))
 				.when(storeReader).readSingleStore(queryStoreId);
 			doReturn(changedStore)
@@ -153,7 +157,7 @@ class StoreServiceTest extends ServiceTest {
 
 			// when
 			Store result = storeService.updateStoreInfo(
-				nonChangedStore.getStoreId(),
+				queryOwnerId,
 				queryStoreId,
 				requestChangeStoreInfo);
 
@@ -161,19 +165,50 @@ class StoreServiceTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(result.getStoreId()).isEqualTo(changedStore.getStoreId());
 
+				verify(ownerReader).findOwner(any(Long.class));
 				verify(storeReader).readSingleStore(any(Long.class));
 				verify(storeWriter).updateStoreInfo(any(Store.class), any(StoreInfo.class));
 			});
 		}
 
 		@Test
+		void 실패_유효하지_않은_OWNER() {
+			//given
+			Long ownerId = GENERAL_OWNER_DIFFERENT().getOwnerId();
+			Long queryStoreId = GENERAL_STORE().getStoreId();
+			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
+
+			doReturn(Optional.empty())
+				.when(ownerReader).findOwner(anyLong());
+			//when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() ->
+						storeService.updateStoreInfo(
+							ownerId,
+							queryStoreId,
+							requestChangeStoreInfo))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_VALID_OWNER);
+
+				verify(ownerReader).findOwner(any(Long.class));
+				verify(storeReader, never())
+					.readSingleStore(ownerId);
+				verify(storeWriter, never())
+					.updateStoreInfo(any(Store.class), any(StoreInfo.class));
+			});
+		}
+
+		@Test
 		void 실패_수정_요청자가_가게_OWNER와_다를시() {
 			// given
-			Long diffOwnerId = GENERAL_OWNER_DIFFERENT().getOwnerId();
+			Owner savedDiffOwner = GENERAL_OWNER_DIFFERENT();
+			Long diffOwnerId = savedDiffOwner.getOwnerId();
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 			Store previousStore = GENERAL_STORE();
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 
+			doReturn(Optional.of(savedDiffOwner))
+				.when(ownerReader).findOwner(diffOwnerId);
 			doReturn(Optional.of(previousStore))
 				.when(storeReader).readSingleStore(queryStoreId);
 
@@ -186,6 +221,7 @@ class StoreServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
 
+				verify(ownerReader).findOwner(any(Long.class));
 				verify(storeReader).readSingleStore(any(Long.class));
 				verify(storeWriter, never())
 					.updateStoreInfo(any(Store.class), any(StoreInfo.class));
@@ -196,10 +232,13 @@ class StoreServiceTest extends ServiceTest {
 		@Test
 		void 실패_유효하지_않는_가게_ID() {
 			// given
-			Long queryOwnerId = GENERAL_OWNER().getOwnerId();
+			Owner savedOwner = GENERAL_OWNER();
+			Long queryOwnerId = savedOwner.getOwnerId();
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 
+			doReturn(Optional.of(savedOwner))
+				.when(ownerReader).findOwner(queryOwnerId);
 			doReturn(Optional.empty())
 				.when(storeReader).readSingleStore(queryStoreId);
 
@@ -213,6 +252,7 @@ class StoreServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
 
+				verify(ownerReader).findOwner(anyLong());
 				verify(storeReader).readSingleStore(any(Long.class));
 				verify(storeWriter, never())
 					.updateStoreInfo(any(Store.class), any(StoreInfo.class));

--- a/domain/domain-pos/src/test/java/fixtures/store/StoreFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/StoreFixture.java
@@ -18,10 +18,6 @@ public class StoreFixture {
 	private static final StoreInfo GENERAL_STORE_INFO = GENERAL_STORE_INFO();
 	private static final StoreInfo GENERAL_CHANGED_STORE_INFO = CHANGED_GENERAL_STORE_INFO();
 
-	public static StoreInfo CREATE_REQUEST_STORE_INFO() {
-		return new StoreInfo();
-	}
-
 	public static Store GENERAL_STORE() {
 		return new Store(
 			STORE_ID,

--- a/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
@@ -1,14 +1,38 @@
 package fixtures.store;
 
+import java.awt.geom.Point2D;
+
 import domain.pos.store.entity.StoreInfo;
 
 public class StoreInfoFixture {
+	// 가게 이름
+	private static final String STORE_NAME = "야밤 주막";
+	private static final String STORE_NAME_2 = "금오 주막";
+	// 가게 위치
+	private static final Point2D.Double STORE_LOCATION = new Point2D.Double(37.123456, 127.123456);
+	private static final Point2D.Double STORE_LOCATION_2 = new Point2D.Double(42.123456, 127.113676);
+	// 가게 상세 설명
+	private static final String STORE_DESCRIPTION = "야밤 주막은 맛있는 음식을 제공합니다.";
+	private static final String STORE_DESCRIPTION_2 = "금오 주막은 맛있는 음식을 제공합니다.";
+	// 가게 이미지 파일 url
+	private static final String STORE_IMAGE_URL = "https://www.yabam.com/store.jpg";
+	private static final String STORE_IMAGE_URL_2 = "https://www.geumoh.com/store.jpg";
 
 	public static StoreInfo GENERAL_STORE_INFO() {
-		return new StoreInfo();
+		return StoreInfo.of(
+			STORE_NAME,
+			STORE_LOCATION,
+			STORE_DESCRIPTION,
+			STORE_IMAGE_URL
+		);
 	}
 
 	public static StoreInfo CHANGED_GENERAL_STORE_INFO() {
-		return new StoreInfo();
+		return StoreInfo.of(
+			STORE_NAME_2,
+			STORE_LOCATION_2,
+			STORE_DESCRIPTION_2,
+			STORE_IMAGE_URL_2
+		);
 	}
 }

--- a/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
@@ -17,13 +17,17 @@ public class StoreInfoFixture {
 	// 가게 이미지 파일 url
 	private static final String STORE_IMAGE_URL = "https://www.yabam.com/store.jpg";
 	private static final String STORE_IMAGE_URL_2 = "https://www.geumoh.com/store.jpg";
+	// 가게 대학교
+	private static final String STORE_UNIVERSITY = "금오공과대학교";
+	private static final String STORE_UNIVERSITY_2 = "서울대학교";
 
 	public static StoreInfo GENERAL_STORE_INFO() {
 		return StoreInfo.of(
 			STORE_NAME,
 			STORE_LOCATION,
 			STORE_DESCRIPTION,
-			STORE_IMAGE_URL
+			STORE_IMAGE_URL,
+			STORE_UNIVERSITY
 		);
 	}
 
@@ -32,7 +36,8 @@ public class StoreInfoFixture {
 			STORE_NAME_2,
 			STORE_LOCATION_2,
 			STORE_DESCRIPTION_2,
-			STORE_IMAGE_URL_2
+			STORE_IMAGE_URL_2,
+			STORE_UNIVERSITY_2
 		);
 	}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,9 +3,11 @@ rootProject.name = 'yabam'
 include(':application:yabam')
 
 
+// application
 include(':application:config')
 include(':application:discovery')
 include(':application:gateway')
+include(':application:auth')
 
 // common
 include(":common:discovery-client")
@@ -13,3 +15,4 @@ include(":common:base")
 
 // domain
 include(":domain:domain-pos")
+


### PR DESCRIPTION
## ✨ 작업 내용

**1️⃣  OIDC 회원가입 Controller API 구현**

- OIDC 회원 가입을 구현 했습니다
- OIDC 는 카카오 , 구글 , 애플 플랫폼만 지원하기 때문에 네이버는 제외 했습니다
- OIDC 구현 이유와 구현에서 사용하는 ID Token 유효성 검사 로직은 노션 페이지를 통해서 공유했습니다

**3️⃣  OIDC 관련 인프라 구성**
- OIDC 공개키가 여러번 요청 했을 때 금지 되기 때문에 추후 redis connection을 이용하여 캐싱을 구현하겠습니다.
- 공개키 클라이언트는 FeignClient를 사용했습니다.


## ✅ 리뷰 요구사항

- OIDC 검증 계층이 Helper 와 Provider 로 구현되어 있는데, 로직이 복잡하여 주석이랑 노션 페이지를 잘 참고하시면 될거 같습니다
