### PR TITLE
메뉴, 메뉴 카테고리 생성 및 리스트 조회 도메인 로직 구현

### DIFF
--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -16,7 +16,25 @@ public enum ErrorCode {
 	// Auth
 	INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0001", "해당 ID 토큰은 유효하지 않습니다."),
 	ABNORMAL_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0002", "해당 ID 토큰은 정상적이지 않습니다"),
-	NOT_MATCHED_PUBLIC_KEY(HttpStatus.NOT_FOUND, "AUTH_0003", "해당 ID 토큰의 공개키를 찾을 수 없습니다");
+	NOT_MATCHED_PUBLIC_KEY(HttpStatus.NOT_FOUND, "AUTH_0003", "해당 ID 토큰의 공개키를 찾을 수 없습니다"),
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_0004", "비밀번호가 일치하지 않습니다."),
+	USERID_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_0005", "존재하지 않는 아이디입니다."),
+	EXIST_SAME_USERID(HttpStatus.CONFLICT, "AUTH_0006", "이미 사용중인 아이디 입니다."),
+	EXIST_SAME_NICKNAME(HttpStatus.CONFLICT, "AUTH_0007", "이미 사용중인 닉네임 입니다."),
+	ADDITIONAL_INFO_NOT_UPDATED(HttpStatus.UNAUTHORIZED, "AUTH_0008", "추가정보가 업데이트되지 않았습니다."),
+
+	// Menu
+	MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_0001", "존재하지 않는 메뉴입니다."),
+
+	// MenuCategory
+	MENU_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_CATEGORY_0001", "존재하지 않는 메뉴 카테고리입니다."),
+
+	// Security
+	NEED_AUTHORIZED(HttpStatus.UNAUTHORIZED, "SECURITY_0001", "인증이 필요합니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "SECURITY_0002", "권한이 없습니다."),
+	JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "SECURITY_0003", "JWT 토큰이 만료되었습니다."),
+	JWT_INVALID(HttpStatus.UNAUTHORIZED, "SECURITY_0004", "JWT 토큰이 올바르지 않습니다."),
+	JWT_NOT_EXIST(HttpStatus.UNAUTHORIZED, "SECURITY_0005", "JWT 토큰이 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/domain/domain-pos/build.gradle
+++ b/domain/domain-pos/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     // spring compoment annotation
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.springframework.boot:spring-boot-starter-data-jpa'
-
+    implementation 'org.springframework.data:spring-data-commons:3.4.3'
+    
     // common exception
     implementation project(":common:base")
 
@@ -19,5 +20,4 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
-
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/Menu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/Menu.java
@@ -1,0 +1,19 @@
+package domain.pos.menu.entity;
+
+import domain.pos.store.entity.StoreInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Menu {
+	private MenuInfo menuInfo;
+	private StoreInfo storeInfo;
+	private MenuCategory menuCategory;
+
+	@Builder
+	public Menu(MenuInfo menuInfo, StoreInfo storeInfo, MenuCategory menuCategory) {
+		this.menuInfo = menuInfo;
+		this.storeInfo = storeInfo;
+		this.menuCategory = menuCategory;
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategory.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategory.java
@@ -1,0 +1,16 @@
+package domain.pos.menu.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MenuCategory {
+	private Long menuCategoryId;
+	private String menuCategoryName;
+
+	@Builder
+	public MenuCategory(Long menuCategoryId, String menuCategoryName) {
+		this.menuCategoryId = menuCategoryId;
+		this.menuCategoryName = menuCategoryName;
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuInfo.java
@@ -1,0 +1,27 @@
+package domain.pos.menu.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MenuInfo {
+	private Long menuId;
+	private int sortOrder;
+	private String menuName;
+	private int price;
+	private String description;
+	private String imageUrl;
+	private boolean isSoldOut;
+
+	@Builder
+	public MenuInfo(Long menuId, int sortOrder, String menuName, int price, String description, String imageUrl,
+		boolean isSoldOut) {
+		this.menuId = menuId;
+		this.sortOrder = sortOrder;
+		this.menuName = menuName;
+		this.price = price;
+		this.description = description;
+		this.imageUrl = imageUrl;
+		this.isSoldOut = isSoldOut;
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryReader.java
@@ -1,0 +1,19 @@
+package domain.pos.menu.implement;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.repository.MenuCategoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuCategoryReader {
+	private final MenuCategoryRepository menuCategoryRepository;
+
+	public Optional<MenuCategory> getMenuCategory(Long categoryId) {
+		return menuCategoryRepository.getMenuCategory(categoryId);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryValidator.java
@@ -1,0 +1,19 @@
+package domain.pos.menu.implement;
+
+import org.springframework.stereotype.Component;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuCategoryValidator {
+	private final MenuCategoryReader menuCategoryReader;
+
+	public void validateMenuCategory(Long categoryId) {
+		menuCategoryReader.getMenuCategory(categoryId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_CATEGORY_NOT_FOUND));
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryWriter.java
@@ -1,0 +1,17 @@
+package domain.pos.menu.implement;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.repository.MenuCategoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuCategoryWriter {
+	private final MenuCategoryRepository menuCategoryRepository;
+
+	public MenuCategory postMenuCategory(String categoryName) {
+		return menuCategoryRepository.postMenuCategory(categoryName);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
@@ -1,0 +1,25 @@
+package domain.pos.menu.implement;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuReader {
+	private final MenuRepository menuRepository;
+
+	public Optional<MenuInfo> getMenuInfo(Long menuId) {
+		return menuRepository.getMenuInfo(menuId);
+	}
+
+	public Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId) {
+		return menuRepository.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
@@ -1,0 +1,18 @@
+package domain.pos.menu.implement;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuWriter {
+	private final MenuRepository menuRepository;
+
+	public Menu postMenu(Long storeId, Long userId, Long menuCategoryId, MenuInfo menuInfo) {
+		return menuRepository.postMenu(storeId, userId, menuCategoryId, menuInfo);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuCategoryRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuCategoryRepository.java
@@ -1,0 +1,11 @@
+package domain.pos.menu.repository;
+
+import java.util.Optional;
+
+import domain.pos.menu.entity.MenuCategory;
+
+public interface MenuCategoryRepository {
+	MenuCategory postMenuCategory(String categoryName);
+
+	Optional<MenuCategory> getMenuCategory(Long categoryId);
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
@@ -1,0 +1,17 @@
+package domain.pos.menu.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuInfo;
+
+public interface MenuRepository {
+	Menu postMenu(Long storeId, Long userId, Long menuCategoryId, MenuInfo menuInfo);
+
+	Optional<MenuInfo> getMenuInfo(Long menuId);
+
+	Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId);
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
@@ -1,0 +1,20 @@
+package domain.pos.menu.service;
+
+import org.springframework.stereotype.Service;
+
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.implement.MenuCategoryWriter;
+import domain.pos.store.implement.StoreValidator;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MenuCategoryService {
+	private final StoreValidator storeValidator;
+	private final MenuCategoryWriter menuCategoryWriter;
+
+	public MenuCategory postMenuCategory(Long storeId, Long userId, String categoryName) {
+		storeValidator.validateStoreOwner(storeId, userId);
+		return menuCategoryWriter.postMenuCategory(categoryName);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuService.java
@@ -1,0 +1,47 @@
+package domain.pos.menu.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.implement.MenuCategoryValidator;
+import domain.pos.menu.implement.MenuReader;
+import domain.pos.menu.implement.MenuWriter;
+import domain.pos.store.implement.StoreReader;
+import domain.pos.store.implement.StoreValidator;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+	private final StoreValidator storeValidator;
+	private final MenuCategoryValidator menuCategoryValidator;
+	private final StoreReader storeReader;
+	private final MenuReader menuReader;
+	private final MenuWriter menuWriter;
+
+	public Menu postMenu(Long storeId, Long userId, Long menuCategoryId, MenuInfo menuInfo) {
+		storeValidator.validateStoreOwner(storeId, userId);
+		menuCategoryValidator.validateMenuCategory(menuCategoryId);
+		return menuWriter.postMenu(storeId, userId, menuCategoryId, menuInfo);
+	}
+
+	public Slice<MenuInfo> getMenuSlice(Pageable pageable, Long lastMenuId, Long storeId, Long menuCategoryId) {
+		storeReader.readSingleStore(storeId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.NOT_FOUND_STORE));
+		menuCategoryValidator.validateMenuCategory(menuCategoryId);
+
+		MenuInfo lastMenuInfo = null;
+		if (lastMenuId != null) {
+			lastMenuInfo = menuReader.getMenuInfo(lastMenuId)
+				.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+		}
+		return menuReader.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
@@ -6,11 +6,21 @@ import lombok.Getter;
 
 @Getter
 public class StoreInfo {
+	private Long storeId;
 	private final String storeName;
 	private final Point2D.Double location;
 	private final String desciption;
 	private final String headImageUrl;
 	private final String university;
+
+	public StoreInfo(Long storeId, String storeName, Point2D.Double location, String desciption, String headImageUrl, String university) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.location = location;
+		this.desciption = desciption;
+		this.headImageUrl = headImageUrl;
+		this.university = university;
+	}
 
 	private StoreInfo(String storeName, Point2D.Double location, String desciption, String headImageUrl,
 		String university) {

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
@@ -13,7 +13,8 @@ public class StoreInfo {
 	private final String headImageUrl;
 	private final String university;
 
-	public StoreInfo(Long storeId, String storeName, Point2D.Double location, String desciption, String headImageUrl, String university) {
+	public StoreInfo(Long storeId, String storeName, Point2D.Double location, String desciption, String headImageUrl,
+		String university) {
 		this.storeId = storeId;
 		this.storeName = storeName;
 		this.location = location;

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -1,0 +1,23 @@
+package domain.pos.store.implement;
+
+import org.springframework.stereotype.Component;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.store.entity.Store;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoreValidator {
+	private final StoreReader storeReader;
+
+	public void validateStoreOwner(Long storeId, Long userId) {
+		Store store = storeReader.readSingleStore(storeId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.NOT_FOUND_STORE));
+		if (!store.getStoreOwner().getOwnerId().equals(userId)) {
+			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
+		}
+	}
+}

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuCategoryServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuCategoryServiceTest.java
@@ -1,0 +1,96 @@
+package domain.pos.menu;
+
+import static fixtures.menu.MenuCategoryFixture.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import base.ServiceTest;
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.implement.MenuCategoryWriter;
+import domain.pos.menu.service.MenuCategoryService;
+import domain.pos.store.implement.StoreValidator;
+
+public class MenuCategoryServiceTest extends ServiceTest {
+	@Mock
+	private StoreValidator storeValidator;
+	@Mock
+	private MenuCategoryWriter menuCategoryWriter;
+	@InjectMocks
+	private MenuCategoryService menuCategoryService;
+
+	@Nested
+	@DisplayName("메뉴 카테고리 생성")
+	class postMenuCategory {
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final String categoryName = "categoryName";
+
+		private final Long menuCategoryId = 1L;
+
+		@Test
+		void 메뉴_카테고리_생성_성공() {
+			// given
+			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId, categoryName);
+
+			BDDMockito.given(menuCategoryWriter.postMenuCategory(categoryName))
+				.willReturn(menuCategory);
+
+			// when
+			MenuCategory serviceMenuCategory = menuCategoryService.postMenuCategory(storeId, userId, categoryName);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(serviceMenuCategory.getMenuCategoryId()).isEqualTo(menuCategoryId);
+				softly.assertThat(serviceMenuCategory.getMenuCategoryName()).isEqualTo(categoryName);
+			});
+		}
+
+		@Test
+		void 주점_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.postMenuCategory(storeId, userId, categoryName))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryWriter, never())
+					.postMenuCategory(categoryName);
+			});
+		}
+
+		@Test
+		void 점주_인증_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.postMenuCategory(storeId, userId, categoryName))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryWriter, never())
+					.postMenuCategory(categoryName);
+			});
+		}
+	}
+}

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
@@ -1,0 +1,277 @@
+package domain.pos.menu;
+
+import static fixtures.member.OwnerFixture.*;
+import static fixtures.menu.MenuCategoryFixture.*;
+import static fixtures.menu.MenuFixture.*;
+import static fixtures.menu.MenuInfoFixture.*;
+import static fixtures.store.StoreFixture.*;
+import static fixtures.store.StoreInfoFixture.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import base.ServiceTest;
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.implement.MenuCategoryValidator;
+import domain.pos.menu.implement.MenuReader;
+import domain.pos.menu.implement.MenuWriter;
+import domain.pos.menu.service.MenuService;
+import domain.pos.store.entity.Store;
+import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.implement.StoreReader;
+import domain.pos.store.implement.StoreValidator;
+
+public class MenuServiceTest extends ServiceTest {
+	@Mock
+	private StoreValidator storeValidator;
+	@Mock
+	private MenuCategoryValidator menuCategoryValidator;
+	@Mock
+	private StoreReader storeReader;
+	@Mock
+	private MenuReader menuReader;
+	@Mock
+	private MenuWriter menuWriter;
+	@InjectMocks
+	private MenuService menuService;
+
+	@Nested
+	@DisplayName("메뉴 생성")
+	class postMenu {
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final Long menuCategoryId = 3L;
+		private final MenuInfo requestMenuInfo = REQUEST_MENU_INFO();
+
+		private final Long menuId = 3L;
+
+		@Test
+		void 메뉴_생성_성공() {
+			// given
+			StoreInfo storeInfo = GENERAL_STORE_INFO();
+			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId);
+			Menu menu = CUSTOM_MENU(REQUEST_TO_ENTITY(menuId, requestMenuInfo), storeInfo, menuCategory);
+
+			BDDMockito.given(menuWriter.postMenu(storeId, userId, menuCategoryId, requestMenuInfo))
+				.willReturn(menu);
+
+			// when
+			Menu serviceMenu = menuService.postMenu(storeId, userId, menuCategoryId, requestMenuInfo);
+
+			// then
+			assertSoftly(softly -> {
+				MenuInfo serviceMenuInfo = serviceMenu.getMenuInfo();
+				StoreInfo serviceStoreInfo = serviceMenu.getStoreInfo();
+				MenuCategory serviceMenuCategory = serviceMenu.getMenuCategory();
+
+				softly.assertThat(serviceMenuInfo.getMenuId()).isEqualTo(menuId);
+				softly.assertThat(serviceMenuInfo.getMenuName()).isEqualTo(requestMenuInfo.getMenuName());
+				softly.assertThat(serviceMenuInfo.getPrice()).isEqualTo(requestMenuInfo.getPrice());
+				softly.assertThat(serviceMenuInfo.getDescription()).isEqualTo(requestMenuInfo.getDescription());
+				softly.assertThat(serviceMenuInfo.getImageUrl()).isEqualTo(requestMenuInfo.getImageUrl());
+
+				softly.assertThat(serviceStoreInfo.getStoreId()).isEqualTo(storeInfo.getStoreId());
+
+				softly.assertThat(serviceMenuCategory.getMenuCategoryId()).isEqualTo(menuCategory.getMenuCategoryId());
+			});
+		}
+
+		@Test
+		void 주점_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuService.postMenu(storeId, userId, menuCategoryId, requestMenuInfo))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(menuCategoryId);
+				verify(menuWriter, never())
+					.postMenu(storeId, userId, menuCategoryId, requestMenuInfo);
+			});
+		}
+
+		@Test
+		void 점주_인증_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuService.postMenu(storeId, userId, menuCategoryId, requestMenuInfo))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(menuCategoryId);
+				verify(menuWriter, never())
+					.postMenu(storeId, userId, menuCategoryId, requestMenuInfo);
+			});
+		}
+
+		@Test
+		void 메뉴_카테고리_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.MENU_CATEGORY_NOT_FOUND))
+				.when(menuCategoryValidator)
+				.validateMenuCategory(menuCategoryId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuService.postMenu(storeId, userId, menuCategoryId, requestMenuInfo))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_CATEGORY_NOT_FOUND);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator)
+					.validateMenuCategory(menuCategoryId);
+				verify(menuWriter, never())
+					.postMenu(storeId, userId, menuCategoryId, requestMenuInfo);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 리스트 조회")
+	class getMenuSlice {
+		private final int size = 10;
+		private final boolean hasNext = false;
+		private final Pageable pageable = Pageable.ofSize(size);
+		private final Long lastMenuId = 10L;
+		private final Long storeId = 1L;
+		private final Long menuCategoryId = 1L;
+
+		private final Long userId = 1L;
+
+		@Test
+		void 메뉴_리스트_조회_성공() {
+			// given
+			Store store = CUSTOM_STORE(storeId, CUSTOM_STORE_INFO(storeId), CUSTOM_OWNER(userId));
+			MenuInfo lastMenuInfo = CUSTOM_MENU_INFO(lastMenuId);
+			MenuInfo nextMenuInfo = CUSTOM_MENU_INFO(lastMenuId + 1);
+			Slice<MenuInfo> menuSlice = new SliceImpl<>(new ArrayList<>(List.of(nextMenuInfo)), pageable, hasNext);
+
+			BDDMockito.given(storeReader.readSingleStore(storeId))
+				.willReturn(Optional.of(store));
+			BDDMockito.given(menuReader.getMenuInfo(lastMenuId))
+				.willReturn(Optional.of(lastMenuInfo));
+			BDDMockito.given(menuReader.getMenuSlice(pageable, lastMenuInfo, menuCategoryId))
+				.willReturn(menuSlice);
+
+			// when
+			Slice<MenuInfo> serviceMenuSlice = menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(serviceMenuSlice.getSize()).isEqualTo(size);
+				softly.assertThat(serviceMenuSlice.hasNext()).isEqualTo(hasNext);
+				softly.assertThat(serviceMenuSlice.getContent().getFirst().getMenuId()).isEqualTo(lastMenuId + 1);
+			});
+		}
+
+		@Test
+		void 주점_조회_실패() {
+			// given
+			BDDMockito.given(storeReader.readSingleStore(storeId))
+				.willReturn(Optional.empty());
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeReader)
+					.readSingleStore(storeId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(menuCategoryId);
+				verify(menuReader, never())
+					.getMenuInfo(lastMenuId);
+				verify(menuReader, never())
+					.getMenuSlice(any(Pageable.class), any(MenuInfo.class), any(Long.class));
+			});
+		}
+
+		@Test
+		void 카테고리_조회_실패() {
+			// given
+			Store store = CUSTOM_STORE(storeId, CUSTOM_STORE_INFO(storeId), CUSTOM_OWNER(userId));
+			BDDMockito.given(storeReader.readSingleStore(any(Long.class)))
+				.willReturn(Optional.of(store));
+
+			doThrow(new ServiceException(ErrorCode.MENU_CATEGORY_NOT_FOUND))
+				.when(menuCategoryValidator)
+				.validateMenuCategory(menuCategoryId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_CATEGORY_NOT_FOUND);
+				verify(storeReader)
+					.readSingleStore(storeId);
+				verify(menuCategoryValidator)
+					.validateMenuCategory(menuCategoryId);
+				verify(menuReader, never())
+					.getMenuInfo(lastMenuId);
+				verify(menuReader, never())
+					.getMenuSlice(any(Pageable.class), any(MenuInfo.class), any(Long.class));
+			});
+		}
+
+		@Test
+		void 메뉴_조회_실패() {
+			// given
+			Store store = CUSTOM_STORE(storeId, CUSTOM_STORE_INFO(storeId), CUSTOM_OWNER(userId));
+			BDDMockito.given(storeReader.readSingleStore(any(Long.class)))
+				.willReturn(Optional.of(store));
+			BDDMockito.given(menuReader.getMenuInfo(any(Long.class)))
+				.willReturn(Optional.empty());
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_FOUND);
+				verify(storeReader)
+					.readSingleStore(storeId);
+				verify(menuCategoryValidator)
+					.validateMenuCategory(menuCategoryId);
+				verify(menuReader)
+					.getMenuInfo(lastMenuId);
+				verify(menuReader, never())
+					.getMenuSlice(any(Pageable.class), any(MenuInfo.class), any(Long.class));
+			});
+		}
+	}
+}

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
@@ -193,7 +193,7 @@ public class MenuServiceTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(serviceMenuSlice.getSize()).isEqualTo(size);
 				softly.assertThat(serviceMenuSlice.hasNext()).isEqualTo(hasNext);
-				softly.assertThat(serviceMenuSlice.getContent().getFirst().getMenuId()).isEqualTo(lastMenuId + 1);
+				softly.assertThat(serviceMenuSlice.getContent().get(0).getMenuId()).isEqualTo(lastMenuId + 1);
 			});
 		}
 

--- a/domain/domain-pos/src/test/java/fixtures/member/OwnerFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/member/OwnerFixture.java
@@ -14,4 +14,8 @@ public class OwnerFixture {
 	public static Owner GENERAL_OWNER_DIFFERENT() {
 		return new Owner(OWNER_ID_DIFFERENT);
 	}
+
+	public static Owner CUSTOM_OWNER(Long ownerId) {
+		return new Owner(ownerId);
+	}
 }

--- a/domain/domain-pos/src/test/java/fixtures/menu/MenuCategoryFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/menu/MenuCategoryFixture.java
@@ -1,0 +1,22 @@
+package fixtures.menu;
+
+import domain.pos.menu.entity.MenuCategory;
+
+public class MenuCategoryFixture {
+	private static final Long MENU_CATEGORY_ID = 1L;
+	private static final String CATEGORY_NAME = "categoryName";
+
+	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId) {
+		return MenuCategory.builder()
+			.menuCategoryId(menuCategoryId)
+			.menuCategoryName(CATEGORY_NAME)
+			.build();
+	}
+
+	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId, String categoryName) {
+		return MenuCategory.builder()
+			.menuCategoryId(menuCategoryId)
+			.menuCategoryName(categoryName)
+			.build();
+	}
+}

--- a/domain/domain-pos/src/test/java/fixtures/menu/MenuFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/menu/MenuFixture.java
@@ -1,0 +1,16 @@
+package fixtures.menu;
+
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.store.entity.StoreInfo;
+
+public class MenuFixture {
+	public static Menu CUSTOM_MENU(MenuInfo menuInfo, StoreInfo storeInfo, MenuCategory menuCategory) {
+		return Menu.builder()
+			.menuInfo(menuInfo)
+			.storeInfo(storeInfo)
+			.menuCategory(menuCategory)
+			.build();
+	}
+}

--- a/domain/domain-pos/src/test/java/fixtures/menu/MenuInfoFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/menu/MenuInfoFixture.java
@@ -1,0 +1,50 @@
+package fixtures.menu;
+
+import domain.pos.menu.entity.MenuInfo;
+
+public class MenuInfoFixture {
+	private static final Long GENERAL_MENU_ID = 1L;
+	private static final String GENERAL_MENU_NAME = "menu name";
+	private static final int GENERAL_PRICE = 10000;
+	private static final String GENERAL_DESCRIPTION = "menu description";
+	private static final String GENERAL_IMAGEURL = "imageURL";
+
+	public static MenuInfo REQUEST_MENU_INFO() {
+		return MenuInfo.builder()
+			.menuName(GENERAL_MENU_NAME)
+			.price(GENERAL_PRICE)
+			.description(GENERAL_DESCRIPTION)
+			.imageUrl(GENERAL_IMAGEURL)
+			.build();
+	}
+
+	public static MenuInfo GENERAL_MENU_INFO() {
+		return MenuInfo.builder()
+			.menuId(GENERAL_MENU_ID)
+			.menuName(GENERAL_MENU_NAME)
+			.price(GENERAL_PRICE)
+			.description(GENERAL_DESCRIPTION)
+			.imageUrl(GENERAL_IMAGEURL)
+			.build();
+	}
+
+	public static MenuInfo CUSTOM_MENU_INFO(Long menuId) {
+		return MenuInfo.builder()
+			.menuId(menuId)
+			.menuName(GENERAL_MENU_NAME)
+			.price(GENERAL_PRICE)
+			.description(GENERAL_DESCRIPTION)
+			.imageUrl(GENERAL_IMAGEURL)
+			.build();
+	}
+
+	public static MenuInfo REQUEST_TO_ENTITY(Long menuId, MenuInfo requestMenuInfo) {
+		return MenuInfo.builder()
+			.menuId(menuId)
+			.menuName(requestMenuInfo.getMenuName())
+			.price(requestMenuInfo.getPrice())
+			.description(requestMenuInfo.getDescription())
+			.imageUrl(requestMenuInfo.getImageUrl())
+			.build();
+	}
+}

--- a/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/StoreInfoFixture.java
@@ -40,4 +40,8 @@ public class StoreInfoFixture {
 			STORE_UNIVERSITY_2
 		);
 	}
+
+	public static StoreInfo CUSTOM_STORE_INFO(Long storeId) {
+		return new StoreInfo(storeId, STORE_NAME, STORE_LOCATION, STORE_DESCRIPTION, STORE_IMAGE_URL, STORE_UNIVERSITY);
+	}
 }


### PR DESCRIPTION
1️⃣ **메뉴 생성 및 메뉴 리스트 조회 도메인 로직 구현**
---
- ![image](https://github.com/user-attachments/assets/de2bf358-1ae7-419c-9f6e-154107a2335b)
- ![image](https://github.com/user-attachments/assets/77b3cfbe-d98b-4d5d-b8a3-39d41dddefff)

2️⃣ **메뉴 카테고리 생성 도메인 로직 구현**
---
- ![image](https://github.com/user-attachments/assets/95408c74-6d83-45b2-bf28-3f04f723de1e)

3️⃣ **도메인 계층 단위 테스트 코드 작성**
---