### PR TITLE
Store 오픈/마감 도메인 로직 작성 및 Sale 도메인 모델링

### DIFF
--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
 	// Store
 	NOT_EQUAL_STORE_OWNER(HttpStatus.CONFLICT, "STORE_0001", "해당 가게의 점주가 아닙니다"),
 	NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "STORE_0002", "해당 가게를 찾을 수 없습니다"),
+	CONFLICT_OPEN_STORE(HttpStatus.CONFLICT, "STORE_0003", "해당 가게 활성화 여부가 충돌된 요청입니다"),
+	CONFLICT_CLOSE_STORE(HttpStatus.CONFLICT, "STORE_004", "가게가 이미 종료되었습니다."),
 
 	// Auth
 	INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0001", "해당 ID 토큰은 유효하지 않습니다."),

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/Sale.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/Sale.java
@@ -1,0 +1,32 @@
+package domain.pos.store.entity;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import lombok.Getter;
+
+@Getter
+public class Sale {
+	private final Long saleId;
+	private final LocalDateTime openDateTime;
+	private final Optional<LocalDateTime> closeDateTime;
+	private final Store store;
+
+	private Sale(Long saleId, LocalDateTime openDateTime, LocalDateTime closeDateTime, Store store) {
+		this.saleId = saleId;
+		this.openDateTime = openDateTime;
+		this.closeDateTime = Optional.ofNullable(closeDateTime);
+		this.store = store;
+	}
+
+	public static Sale of(Long saleId,
+		LocalDateTime openDateTime,
+		LocalDateTime closeDateTime,
+		Store store) {
+		return new Sale(saleId,
+			openDateTime,
+			closeDateTime,
+			store);
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 @Getter
 public class Store {
 	private final Long storeId;
+	private final Boolean isOpen;
 	private final StoreInfo storeInfo;
 	private final Owner storeOwner;
 
-	public Store(Long storeId, StoreInfo storeInfo, Owner storeOwner) {
+	public Store(Long storeId, Boolean isOpen, StoreInfo storeInfo, Owner storeOwner) {
 		this.storeId = storeId;
+		this.isOpen = isOpen;
 		this.storeInfo = storeInfo;
 		this.storeOwner = storeOwner;
 	}

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleReader.java
@@ -1,0 +1,20 @@
+package domain.pos.store.implement;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.store.entity.Sale;
+import domain.pos.store.repository.SaleRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SaleReader {
+	private final SaleRepository saleRepository;
+
+	public Optional<Sale> readSingleSale(Long saleId) {
+		return saleRepository.findSaleBySaleId(saleId);
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleWriter.java
@@ -1,0 +1,22 @@
+package domain.pos.store.implement;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.store.entity.Sale;
+import domain.pos.store.entity.Store;
+import domain.pos.store.repository.SaleRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SaleWriter {
+	private final SaleRepository saleRepository;
+
+	public Sale createSale(Store previousStore) {
+		return saleRepository.createSale(previousStore);
+	}
+
+	public Sale closeSale(Sale savedSale, Store closeStore) {
+		return saleRepository.closeSale(savedSale, closeStore);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -5,10 +5,14 @@ import org.springframework.stereotype.Component;
 import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
+import domain.pos.member.entity.UserPassport;
+import domain.pos.member.entity.UserRole;
 import domain.pos.store.entity.Store;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class StoreValidator {
 	private final StoreReader storeReader;
@@ -19,5 +23,33 @@ public class StoreValidator {
 		if (!store.getStoreOwner().getOwnerId().equals(userId)) {
 			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
 		}
+	}
+
+	public Store validateStoreModifyByUser(UserPassport userPassport, Long queryStoreId) {
+		if (isOwner(userPassport)) {
+			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
+			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
+		}
+		final Store previousStore = storeReader.readSingleStore(queryStoreId)
+			.orElseThrow(() -> {
+				log.warn("해당 Store 존재하지 않음: storeId={}", queryStoreId);
+				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
+			});
+
+		if (isEqualSavedStoreOwnerAndQueryOwner(userPassport.getUserId(), previousStore)) {
+			log.warn("요청 유저는 Store 소유자와 다름: userId={}, queryStoreId={}", userPassport.getUserId(), queryStoreId);
+			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
+		}
+		return previousStore;
+	}
+
+	// 점주가 아닌 사용자인지 확인
+	private boolean isOwner(UserPassport userPassport) {
+		return !userPassport.getUserRole().equals(UserRole.ROLE_OWNER);
+	}
+
+	// 가게 소유자와 요청 점주가 같은지 확인
+	private boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
+		return !previousStore.getStoreOwner().getOwnerId().equals(ownerId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
@@ -24,4 +24,8 @@ public class StoreWriter {
 	public void deleteStore(Store previousStore) {
 		storeRepository.deleteStore(previousStore);
 	}
+
+	public Store modifyStoreOpenStatus(Store previousStore) {
+		return storeRepository.changeStoreOpenStatus(previousStore);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/SaleRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/SaleRepository.java
@@ -1,0 +1,14 @@
+package domain.pos.store.repository;
+
+import java.util.Optional;
+
+import domain.pos.store.entity.Sale;
+import domain.pos.store.entity.Store;
+
+public interface SaleRepository {
+	Sale createSale(Store previousStore);
+
+	Optional<Sale> findSaleBySaleId(Long saleId);
+
+	Sale closeSale(Sale savedSale, Store closeStore);
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -14,4 +14,6 @@ public interface StoreRepository {
 	Store changeStoreInfo(Store previousStore, StoreInfo requestChangeStoreInfo);
 
 	void deleteStore(Store previousStore);
+
+	Store changeStoreOpenStatus(Store previousStore);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
@@ -1,0 +1,77 @@
+package domain.pos.store.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.member.entity.UserPassport;
+import domain.pos.member.entity.UserRole;
+import domain.pos.store.entity.Sale;
+import domain.pos.store.entity.Store;
+import domain.pos.store.implement.SaleReader;
+import domain.pos.store.implement.SaleWriter;
+import domain.pos.store.implement.StoreValidator;
+import domain.pos.store.implement.StoreWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SaleService {
+	private final SaleWriter saleWriter;
+	private final SaleReader saleReader;
+	private final StoreWriter storeWriter;
+	private final StoreValidator storeValidator;
+
+	@Transactional
+	public Sale openStore(final UserPassport userPassport, final Long storeId) {
+		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, storeId);
+
+		if (previousStore.getIsOpen()) {
+			log.warn("가게 활성화 변경 실패: userId={}, storeId={}", userPassport.getUserId(), storeId);
+			throw new ServiceException(ErrorCode.CONFLICT_OPEN_STORE);
+		}
+		final Store opendStore = storeWriter.modifyStoreOpenStatus(previousStore);
+		final Sale createdSale = saleWriter.createSale(opendStore);
+		log.info("가게 활성화 성공 : userId={}, storeId={}, saleId={}", userPassport.getUserId(), storeId,
+			createdSale.getSaleId());
+		return createdSale;
+	}
+
+	@Transactional
+	public Sale closeStore(final UserPassport userPassport, final Long saleId) {
+		if (isOwner(userPassport)) {
+			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
+			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
+		}
+		final Sale savedSale = saleReader.readSingleSale(saleId)
+			.orElseThrow(() -> {
+				log.warn("가게 조회 실패: saleId={}", saleId);
+				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
+			});
+		savedSale.getCloseDateTime()
+			.ifPresent((dateTime) -> {
+				log.warn("이미 종료된 Sale.: userId={}, saleId={}", userPassport.getUserId(), saleId);
+				throw new ServiceException(ErrorCode.CONFLICT_CLOSE_STORE);
+			});
+		if (!savedSale.getStore().getIsOpen()) {
+			log.warn("이미 종료된 가게 상태: userId={}, storeId={}", userPassport.getUserId(),
+				savedSale.getStore().getStoreId());
+			throw new ServiceException(ErrorCode.CONFLICT_CLOSE_STORE);
+		}
+		final Store closedStore = storeWriter.modifyStoreOpenStatus(savedSale.getStore());
+		final Sale closedSale = saleWriter.closeSale(savedSale, closedStore);
+		log.info("가게 종료 성공 : userId={}, storeId={}, saleId={}", userPassport.getUserId(),
+			savedSale.getStore().getStoreId(), closedSale.getSaleId());
+		return closedSale;
+	}
+
+	// 점주가 아닌 사용자인지 확인
+	private boolean isOwner(UserPassport userPassport) {
+		return !userPassport.getUserRole().equals(UserRole.ROLE_OWNER);
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -10,6 +10,7 @@ import domain.pos.member.entity.UserRole;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
 import domain.pos.store.implement.StoreReader;
+import domain.pos.store.implement.StoreValidator;
 import domain.pos.store.implement.StoreWriter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class StoreService {
 	private final StoreWriter storeWriter;
 	private final StoreReader storeReader;
+	private final StoreValidator storeValidator;
 
 	public Long createStore(final UserPassport userPassport, final StoreInfo createRequestStoreInfo) {
 		if (isOwner(userPassport)) {
@@ -50,21 +52,8 @@ public class StoreService {
 		final UserPassport userPassport,
 		final Long queryStoreId,
 		final StoreInfo requestChangeStoreInfo) {
-		if (isOwner(userPassport)) {
-			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
-			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
-		}
-		final Store previousStore = storeReader.readSingleStore(queryStoreId)
-			.orElseThrow(() -> {
-				log.warn("가게 조회 실패: storeId={}", queryStoreId);
-				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
-			});
 
-		if (isEqualSavedStoreOwnerAndQueryOwner(userPassport.getUserId(), previousStore)) {
-			log.warn("수정 요청 실패: userId={}, queryStoreId={}", userPassport.getUserId(), queryStoreId);
-			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
-		}
-
+		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, queryStoreId);
 		Store updatedStore = storeWriter
 			.updateStoreInfo(previousStore, requestChangeStoreInfo);
 		log.info("가게 정보 수정 성공 : userId={}, storeId={}", userPassport.getUserId(), queryStoreId);
@@ -72,25 +61,8 @@ public class StoreService {
 		return updatedStore;
 	}
 
-	// 가게 소유자와 요청 점주가 같은지 확인
-	private boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
-		return !previousStore.getStoreOwner().getOwnerId().equals(ownerId);
-	}
-
-	public void deleteStore(UserPassport userPassport, Long storeId) {
-		if (isOwner(userPassport)) {
-			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
-			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
-		}
-		final Store previousStore = storeReader.readSingleStore(storeId)
-			.orElseThrow(() -> {
-				log.warn("가게 조회 실패: storeId={}", storeId);
-				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
-			});
-		if (isEqualSavedStoreOwnerAndQueryOwner(userPassport.getUserId(), previousStore)) {
-			log.warn("삭제 요청 실패: userId={}, queryStoreId={}", userPassport.getUserId(), storeId);
-			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
-		}
+	public void deleteStore(final UserPassport userPassport, final Long storeId) {
+		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, storeId);
 		storeWriter.deleteStore(previousStore);
 		log.info("가게 삭제 성공 : userId={}, storeId={}", userPassport.getUserId(), storeId);
 	}

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
@@ -1,0 +1,305 @@
+package domain.pos.store.service;
+
+import static fixtures.member.UserFixture.*;
+import static fixtures.store.SaleFixture.*;
+import static fixtures.store.StoreFixture.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import base.ServiceTest;
+import domain.pos.member.entity.UserPassport;
+import domain.pos.store.entity.Sale;
+import domain.pos.store.entity.Store;
+import domain.pos.store.implement.SaleReader;
+import domain.pos.store.implement.SaleWriter;
+import domain.pos.store.implement.StoreValidator;
+import domain.pos.store.implement.StoreWriter;
+
+class SaleServiceTest extends ServiceTest {
+	@Mock
+	private SaleWriter saleWriter;
+
+	@Mock
+	private SaleReader saleReader;
+
+	@Mock
+	private StoreWriter storeWriter;
+
+	@Mock
+	private StoreValidator storeValidator;
+
+	@InjectMocks
+	private SaleService saleService;
+
+	@Nested
+	@DisplayName("store 오픈")
+	class openStore {
+		@Test
+		void 성공() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Store savedStore = GENERAL_STORE();
+			Store opendStore = GENERAL_OPEN_STORE();
+			Long queryStoreId = savedStore.getStoreId();
+			Sale createdSale = GENERAL_OPEN_SALE(opendStore);
+
+			doReturn(savedStore)
+				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+			doReturn(opendStore)
+				.when(storeWriter).modifyStoreOpenStatus(savedStore);
+			doReturn(createdSale)
+				.when(saleWriter).createSale(opendStore);
+			// when
+			Sale result = saleService.openStore(queryUserPassport, queryStoreId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isEqualTo(createdSale);
+				softly.assertThat(result.getStore().getIsOpen()).isTrue();
+
+				verify(storeValidator)
+					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+				verify(storeWriter)
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter)
+					.createSale(any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_요청_유저가_점주가_아닐때() {
+			// given
+			UserPassport queryUserPassport = GENERAL_USER_PASSPORT();
+			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
+
+			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))
+				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.openStore(queryUserPassport, queryStoreId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.NOT_VALID_OWNER.getMessage());
+				verify(storeValidator)
+					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.createSale(any(Store.class));
+			});
+
+		}
+
+		@Test
+		void 실패_유효하지_않는_STORE_일때() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
+
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.openStore(queryUserPassport, queryStoreId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.NOT_FOUND_STORE.getMessage());
+				verify(storeValidator)
+					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.createSale(any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_가게주인과_요청유저가_다를때() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
+
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.openStore(queryUserPassport, queryStoreId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.NOT_EQUAL_STORE_OWNER.getMessage());
+				verify(storeValidator)
+					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.createSale(any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_이미_가게가_활성화되어있을때() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Store savedStore = GENERAL_OPEN_STORE();
+			Long queryStoreId = savedStore.getStoreId();
+
+			doReturn(savedStore)
+				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.openStore(queryUserPassport, queryStoreId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.CONFLICT_OPEN_STORE.getMessage());
+				verify(storeValidator)
+					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.createSale(any(Store.class));
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("store 종료")
+	class closeStore {
+		@Test
+		void 성공() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Store savedStore = GENERAL_OPEN_STORE();
+			Sale savedOpenedSale = GENERAL_OPEN_SALE(savedStore);
+			Long querySaleId = savedOpenedSale.getSaleId();
+
+			Store closedStore = GENERAL_STORE();
+			Sale closedSale = GENERAL_CLOSE_SALE(closedStore);
+
+			doReturn(Optional.of(savedOpenedSale))
+				.when(saleReader).readSingleSale(querySaleId);
+			doReturn(closedStore)
+				.when(storeWriter).modifyStoreOpenStatus(savedOpenedSale.getStore());
+			doReturn(closedSale)
+				.when(saleWriter).closeSale(savedOpenedSale, closedStore);
+
+			// when
+			Sale result = saleService.closeStore(queryUserPassport, querySaleId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isEqualTo(closedSale);
+				softly.assertThat(result.getStore().getIsOpen()).isFalse();
+
+				verify(saleReader)
+					.readSingleSale(anyLong());
+				verify(storeWriter)
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter)
+					.closeSale(any(Sale.class), any(Store.class));
+			});
+
+		}
+
+		@Test
+		void 실패_점주가_아닌_USER() {
+			// given
+			UserPassport queryUserPassport = GENERAL_USER_PASSPORT();
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.closeStore(queryUserPassport, 1L))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.NOT_VALID_OWNER.getMessage());
+				verify(saleReader, never())
+					.readSingleSale(anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.closeSale(any(Sale.class), any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_유효하지_않는_SALE_ID() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryDifferentSaleId = 999L;
+
+			doReturn(Optional.empty())
+				.when(saleReader).readSingleSale(queryDifferentSaleId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.closeStore(queryUserPassport, queryDifferentSaleId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.NOT_FOUND_STORE.getMessage());
+				verify(saleReader)
+					.readSingleSale(anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.closeSale(any(Sale.class), any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_이미_종료된_SALE() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Sale savedClosedSale = GENERAL_CLOSE_SALE(GENERAL_STORE());
+
+			doReturn(Optional.of(savedClosedSale))
+				.when(saleReader).readSingleSale(savedClosedSale.getSaleId());
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.closeStore(queryUserPassport, savedClosedSale.getSaleId()))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.CONFLICT_CLOSE_STORE.getMessage());
+				verify(saleReader)
+					.readSingleSale(anyLong());
+				verify(storeWriter, never())
+					.modifyStoreOpenStatus(any(Store.class));
+				verify(saleWriter, never())
+					.closeSale(any(Sale.class), any(Store.class));
+			});
+		}
+
+		@Test
+		void 실패_이미_종료된_가게_상태() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Store savedStore = GENERAL_CLOSE_SALE(GENERAL_STORE()).getStore();
+			Sale savedOpenedSale = GENERAL_OPEN_SALE(savedStore);
+			Long querySaleId = savedOpenedSale.getSaleId();
+			doReturn(Optional.of(savedOpenedSale))
+				.when(saleReader).readSingleSale(querySaleId);
+
+			// when->then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> saleService.closeStore(queryUserPassport, querySaleId))
+					.isInstanceOf(ServiceException.class)
+					.hasMessage(ErrorCode.CONFLICT_CLOSE_STORE.getMessage());
+			});
+
+			verify(saleReader)
+				.readSingleSale(anyLong());
+			verify(storeWriter, never())
+				.modifyStoreOpenStatus(any(Store.class));
+			verify(saleWriter, never())
+				.closeSale(any(Sale.class), any(Store.class));
+		}
+	}
+
+}

--- a/domain/domain-pos/src/test/java/fixtures/store/SaleFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/SaleFixture.java
@@ -1,0 +1,35 @@
+package fixtures.store;
+
+import java.time.LocalDateTime;
+
+import domain.pos.store.entity.Sale;
+import domain.pos.store.entity.Store;
+
+public class SaleFixture {
+	// 판매 고유 ID
+	private static final Long GENERAL_SALE_ID = 1L;
+
+	// 판매 시작 시간
+	private static final LocalDateTime GENERAL_SALE_START_DATETIME = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+	// 판매 마감 시간
+	private static final LocalDateTime GENERAL_SALE_END_DATETIME = LocalDateTime.of(2025, 1, 1, 23, 59);
+
+	public static Sale GENERAL_OPEN_SALE(Store store) {
+		return Sale.of(
+			GENERAL_SALE_ID,
+			GENERAL_SALE_START_DATETIME,
+			null,
+			store
+		);
+	}
+
+	public static Sale GENERAL_CLOSE_SALE(Store store) {
+		return Sale.of(
+			GENERAL_SALE_ID,
+			GENERAL_SALE_START_DATETIME,
+			GENERAL_SALE_END_DATETIME,
+			store
+		);
+	}
+}

--- a/domain/domain-pos/src/test/java/fixtures/store/StoreFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/store/StoreFixture.java
@@ -11,6 +11,10 @@ public class StoreFixture {
 	// 가게 고유 ID
 	private static final Long STORE_ID = 1L;
 
+	// 가게 활성화 여부
+	private static final Boolean IS_OPEN = true;
+	private static final Boolean IS_CLOSED = false;
+
 	// 가게 점주
 	private static final Owner GENERAL_STORE_OWNER = GENERAL_OWNER();
 
@@ -21,6 +25,7 @@ public class StoreFixture {
 	public static Store GENERAL_STORE() {
 		return new Store(
 			STORE_ID,
+			IS_CLOSED,
 			GENERAL_STORE_INFO,
 			GENERAL_STORE_OWNER
 		);
@@ -29,7 +34,17 @@ public class StoreFixture {
 	public static Store CHANGED_GENERAL_STORE() {
 		return new Store(
 			STORE_ID,
+			IS_CLOSED,
 			GENERAL_CHANGED_STORE_INFO,
+			GENERAL_STORE_OWNER
+		);
+	}
+
+	public static Store GENERAL_OPEN_STORE() {
+		return new Store(
+			STORE_ID,
+			IS_OPEN,
+			GENERAL_STORE_INFO,
 			GENERAL_STORE_OWNER
 		);
 	}
@@ -37,6 +52,7 @@ public class StoreFixture {
 	public static Store CUSTOM_STORE(Long storeId, StoreInfo storeInfo, Owner owner) {
 		return new Store(
 			storeId,
+			IS_CLOSED,
 			storeInfo,
 			owner
 		);


### PR DESCRIPTION
## 🍀 작업 사항

### 1️⃣ Sale 모델링
```java
@Getter
public class Sale {
	private final Long saleId;
	private final LocalDateTime openDateTime;
	private final Optional<LocalDateTime> closeDateTime;
	private final Store store;
}
```
### 1️⃣ Store 오픈/마감 도메인 로직 작성

#### 오픈

```mermaid
graph TD

Client -- openStore(userPassport, storeId) --> SaleService["가게 오픈"]

SaleService -- validateStoreModifyByUser(userPassport, storeId) --> StoreValidator["가게 수정 권한 검증"]
StoreValidator -- 실패: 점주 아님 --> Error1["에러 반환: NOT_VALID_OWNER"]
StoreValidator -- 실패: 가게 없음 --> Error2["에러 반환: NOT_FOUND_STORE"]
StoreValidator -- 실패: 소유자 불일치 --> Error3["에러 반환: NOT_EQUAL_STORE_OWNER"]
StoreValidator -- 실패: 이미 오픈됨 --> Error4["에러 반환: CONFLICT_OPEN_STORE"]

StoreValidator -- 검증 성공 --> StoreWriter["가게 오픈 상태 변경"]
StoreWriter --> SaleWriter["Sale 생성"]
```

#### 마감

```mermaid
graph TD

Client -- closeStore(userPassport, saleId) --> SaleService["가게 종료"]

SaleService -- 점주 여부 확인 --> RoleCheck["점주인지 확인"]
RoleCheck -- 점주 아님 --> Error1["에러 반환: NOT_VALID_OWNER"]

SaleService -- readSingleSale(saleId) --> SaleReader["진행 중인 Sale 조회"]
SaleReader -- 없음 --> Error2["에러 반환: NOT_FOUND_STORE"]
SaleReader -- 이미 종료됨 --> Error3["에러 반환: CONFLICT_CLOSE_STORE"]
SaleReader -- 가게 이미 종료됨 --> Error4["에러 반환: CONFLICT_CLOSE_STORE"]

SaleReader -- 유효 --> StoreWriter["가게 종료 상태 변경"]
StoreWriter --> SaleWriter["Sale 종료 처리"]
```


## 💯  의논 사항 


- 해당 도메인 로직에서 트랜잭션에 단위를 생각했을 때 동시성 문제는 발생할 확률이 적고 발생하더라도 위협적이지 않다 판단했습니다.
- 다만 store 의 isOpen을 수정하고 Sale의 데이터도 수정하거나 생성합니다 2개의 독립적인 로직을 논리적인 하나의 단위로 처리해야한다고 판단했습니다. 따라서 @Transactional을 붙일지 TransactionManager를 이용해서 최소한의 범위에서 트랜잭션을 사용할 지 의논해보고 싶습니다


