### PR TITLE
Application 계층 필요 Interceptor 및 AOP 구현

### DIFF
--- a/application/gateway/src/main/java/com/gateway/component/JwtReactiveAuthenticationManager.java
+++ b/application/gateway/src/main/java/com/gateway/component/JwtReactiveAuthenticationManager.java
@@ -50,7 +50,7 @@ public class JwtReactiveAuthenticationManager implements ReactiveAuthenticationM
 	}
 
 	private void validateAdminRole(JwtUserClaim claims) {
-		if (Role.ROLE_ADMIN.equals(claims.role())
+		if (Role.ROLE_ADMIN.equals(claims.userRole())
 			// TODO : RestTemplate 사용하여 admin인지 확인
 			&& !userRestTemplate.isAdmin(claims.userId())) {
 			throw new JwtAccessDeniedException();

--- a/application/gateway/src/main/java/com/gateway/config/SecurityConfig.java
+++ b/application/gateway/src/main/java/com/gateway/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
 			.formLogin(ServerHttpSecurity.FormLoginSpec::disable)
 			.addFilterAt(authenticationWebFilter, SecurityWebFiltersOrder.AUTHENTICATION) // JWT 인증 필터 추가
 			.addFilterBefore(new ExceptionHandlerFilter(), SecurityWebFiltersOrder.AUTHENTICATION) // 예외 처리 필터 추가
-			.addFilterAfter(new AuthenticationToHeaderFilter(serverSecurityContextRepository),
+			.addFilterAfter(
+				new AuthenticationToHeaderFilter(serverSecurityContextRepository, authenticationFailureHandler),
 				SecurityWebFiltersOrder.AUTHENTICATION) // 사용자 정보 헤더 추가 필터 추가
 			.authorizeExchange(exchange -> exchange
 				.anyExchange().authenticated()) // 모든 요청은 인증 필요

--- a/application/gateway/src/main/java/com/gateway/filter/AuthenticationToHeaderFilter.java
+++ b/application/gateway/src/main/java/com/gateway/filter/AuthenticationToHeaderFilter.java
@@ -1,20 +1,37 @@
 package com.gateway.filter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationFailureHandler;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gateway.exception.JwtTokenInvalidException;
 import com.gateway.jwt.JwtAuthentication;
 
 import reactor.core.publisher.Mono;
 
 public class AuthenticationToHeaderFilter implements WebFilter {
+	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final ServerSecurityContextRepository securityContextRepository;
+	private final ServerAuthenticationFailureHandler authenticationFailureHandler;
 
-	public AuthenticationToHeaderFilter(ServerSecurityContextRepository securityContextRepository) {
+	private final String USER_ID = "userId";
+	private final String USER_NICKNAME = "userNickname";
+	private final String USER_ROLE = "userRole";
+	private final String USER_INFO_HEADER = "X-User-Info";
+
+	public AuthenticationToHeaderFilter(ServerSecurityContextRepository securityContextRepository,
+		ServerAuthenticationFailureHandler authenticationFailureHandler) {
 		this.securityContextRepository = securityContextRepository;
+		this.authenticationFailureHandler = authenticationFailureHandler;
 	}
 
 	@Override
@@ -23,12 +40,19 @@ public class AuthenticationToHeaderFilter implements WebFilter {
 			.map(SecurityContext::getAuthentication)
 			.flatMap(authentication -> {
 				JwtAuthentication jwtAuthentication = (JwtAuthentication)authentication;
-				String userId = String.valueOf(jwtAuthentication.userId()); // 예시: 사용자 ID
-				String authorities = jwtAuthentication.role().name(); // 예시: 권한 정보
 
-				// ServerWebExchange에 헤더 추가
-				exchange.getRequest().getHeaders().add("X-User-Id", userId);
-				exchange.getRequest().getHeaders().add("X-Authorities", authorities);
+				Map<String, Object> userInfo = new HashMap<>();
+				userInfo.put(USER_ID, String.valueOf(jwtAuthentication.userId()));
+				userInfo.put(USER_NICKNAME, jwtAuthentication.userNickname());
+				userInfo.put(USER_ROLE, jwtAuthentication.userRole().name());
+
+				try {
+					String userInfoJson = objectMapper.writeValueAsString(userInfo);
+					exchange.getRequest().getHeaders().add(USER_INFO_HEADER, userInfoJson);
+				} catch (JsonProcessingException e) {
+					authenticationFailureHandler.onAuthenticationFailure(new WebFilterExchange(exchange, chain),
+						new JwtTokenInvalidException(e));
+				}
 
 				return chain.filter(exchange);
 			})

--- a/application/gateway/src/main/java/com/gateway/jwt/JwtAuthentication.java
+++ b/application/gateway/src/main/java/com/gateway/jwt/JwtAuthentication.java
@@ -11,23 +11,25 @@ import com.gateway.user.Role;
 
 public record JwtAuthentication(
 	Long userId,
-	Role role
+	String userNickname,
+	Role userRole
 ) implements Authentication {
 
 	public JwtAuthentication(JwtUserClaim claims) {
 		this(
 			claims.userId(),
-			claims.role()
+			claims.userNickname(),
+			claims.userRole()
 		);
 	}
 
 	public static JwtAuthentication anonymousAuthentication() {
-		return new JwtAuthentication(null, Role.ROLE_ANONYMOUS);
+		return new JwtAuthentication(null, "Anonymous", Role.ROLE_ANONYMOUS);
 	}
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return Collections.singleton(new SimpleGrantedAuthority(this.role().name()));
+		return Collections.singleton(new SimpleGrantedAuthority(this.userRole().name()));
 	}
 
 	@Override

--- a/application/gateway/src/main/java/com/gateway/jwt/JwtHandler.java
+++ b/application/gateway/src/main/java/com/gateway/jwt/JwtHandler.java
@@ -1,8 +1,6 @@
 package com.gateway.jwt;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.Optional;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -10,7 +8,6 @@ import javax.crypto.spec.SecretKeySpec;
 import com.gateway.user.Role;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtHandler {
 
 	public static final String USER_ID = "USER_ID";
+	public static final String USER_NICKNAME = "USER_NICKNAME";
 	public static final String USER_ROLE = "USER_ROLE";
 	private static final long MILLI_SECOND = 1000L;
 
@@ -28,36 +26,6 @@ public class JwtHandler {
 		this.jwtProperties = jwtProperties;
 		secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8),
 			Jwts.SIG.HS256.key().build().getAlgorithm());
-	}
-
-	// public Token createTokens(JwtUserClaim jwtUserClaim) {
-	// 	Map<String, Object> tokenClaims = this.createClaims(jwtUserClaim);
-	// 	Date now = new Date(System.currentTimeMillis());
-	// 	long accessTokenExpireIn = jwtProperties.getAccessTokenExpireIn();
-	//
-	// 	String accessToken = Jwts.builder()
-	// 		.claims(tokenClaims)
-	// 		.issuedAt(now)
-	// 		.expiration(new Date(now.getTime() + accessTokenExpireIn * MILLI_SECOND))
-	// 		.signWith(secretKey)
-	// 		.compact();
-	//
-	// 	String refreshToken = UUID.randomUUID().toString();
-	//
-	// 	RefreshTokenData refreshTokenData = new RefreshTokenData(jwtUserClaim.userId(), refreshToken);
-	// 	refreshTokenRepository.saveRefreshToken(refreshTokenData);
-	//
-	// 	return Token.builder()
-	// 		.accessToken(accessToken)
-	// 		.refreshToken(refreshToken)
-	// 		.build();
-	// }
-
-	public Map<String, Object> createClaims(JwtUserClaim jwtUserClaim) {
-		return Map.of(
-			USER_ID, jwtUserClaim.userId(),
-			USER_ROLE, jwtUserClaim.role()
-		);
 	}
 
 	// 필터에서 토큰의 상태를 검증하기 위한 메서드 exception은 사용하는 곳에서 처리
@@ -71,26 +39,10 @@ public class JwtHandler {
 		return this.convert(claims);
 	}
 
-	// 재발급을 위해 token이 만료되었더라도 claim을 반환하는 메서드
-	public Optional<JwtUserClaim> getClaims(String token) {
-		try {
-			Claims claims = Jwts.parser()
-				.verifyWith(secretKey)
-				.build()
-				.parseSignedClaims(token)
-				.getPayload();
-			return Optional.of(this.convert(claims));
-		} catch (ExpiredJwtException e) {
-			Claims claims = e.getClaims();
-			return Optional.of(this.convert(claims));
-		} catch (Exception e) {
-			return Optional.empty();
-		}
-	}
-
 	public JwtUserClaim convert(Claims claims) {
 		return new JwtUserClaim(
 			claims.get(USER_ID, Long.class),
+			claims.get(USER_NICKNAME, String.class),
 			Role.valueOf(claims.get(USER_ROLE, String.class))
 		);
 	}

--- a/application/gateway/src/main/java/com/gateway/jwt/JwtUserClaim.java
+++ b/application/gateway/src/main/java/com/gateway/jwt/JwtUserClaim.java
@@ -4,9 +4,10 @@ import com.gateway.user.Role;
 
 public record JwtUserClaim(
 	Long userId,
-	Role role
+	String userNickname,
+	Role userRole
 ) {
-	public static JwtUserClaim create(Long userId, Role role) {
-		return new JwtUserClaim(userId, role);
+	public static JwtUserClaim create(Long userId, String userNickname, Role userRole) {
+		return new JwtUserClaim(userId, userNickname, userRole);
 	}
 }

--- a/application/gateway/src/main/java/com/gateway/user/Role.java
+++ b/application/gateway/src/main/java/com/gateway/user/Role.java
@@ -2,7 +2,7 @@ package com.gateway.user;
 
 public enum Role {
 	ROLE_ANONYMOUS,
-	ROLE_CUSTOMER,
+	ROLE_USER,
 	ROLE_OWNER,
 	ROLE_ADMIN;
 }

--- a/application/yabam/build.gradle
+++ b/application/yabam/build.gradle
@@ -1,7 +1,7 @@
-bootJar{
+bootJar {
     enabled = true
 }
-jar{
+jar {
     enabled = false
 }
 
@@ -15,8 +15,6 @@ dependencies {
     // web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-
-
     // config client
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
@@ -26,10 +24,14 @@ dependencies {
 
     // discovery client module
     implementation(project(':common:discovery-client'))
-
-    // common
+    // common module
     implementation(project(':common:base'))
+    // Domain module
+    implementation project(":domain:domain-pos")
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+
+    // Bootstrap
+    implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 }

--- a/application/yabam/src/main/java/com/application/YabamApplication.java
+++ b/application/yabam/src/main/java/com/application/YabamApplication.java
@@ -2,8 +2,10 @@ package com.application;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class YabamApplication {
 
 	public static void main(String[] args) {

--- a/application/yabam/src/main/java/com/application/festival/yabam/HelloController.java
+++ b/application/yabam/src/main/java/com/application/festival/yabam/HelloController.java
@@ -1,16 +1,26 @@
 package com.application.festival.yabam;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.application.global.authorization.AssignUserPassport;
+import com.application.global.authorization.HasRole;
+
+import domain.pos.member.entity.UserPassport;
+import domain.pos.member.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/yabam")
 public class HelloController {
 
 	@GetMapping("/hello")
-	public String hello() {
-		return "Hello, Yabam!";
+	@HasRole(userRole = UserRole.ROLE_ANONYMOUS)
+	@AssignUserPassport
+	public ResponseEntity<Void> hello(UserPassport userPassport) {
+		return ResponseEntity.ok().build();
 	}
 }

--- a/application/yabam/src/main/java/com/application/global/aop/AssignUserPassportAspect.java
+++ b/application/yabam/src/main/java/com/application/global/aop/AssignUserPassportAspect.java
@@ -1,0 +1,43 @@
+package com.application.global.aop;
+
+import java.lang.reflect.Parameter;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.application.global.interceptor.DeserializingUserPassportInterceptor;
+
+import domain.pos.member.entity.UserPassport;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Aspect
+@Component
+public class AssignUserPassportAspect {
+
+	@Around("@annotation(com.application.global.authorization.AssignUserPassport)")
+	public Object assignUserPassport(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+		ServletRequestAttributes attributes = (ServletRequestAttributes)RequestContextHolder.getRequestAttributes();
+		HttpServletRequest request = attributes.getRequest();
+
+		String attributeName = DeserializingUserPassportInterceptor.USER_INFO_ATTRIBUTE;
+		UserPassport userPassport = (UserPassport)request.getAttribute(attributeName);
+
+		Object[] argValues = proceedingJoinPoint.getArgs();
+		MethodSignature signature = (MethodSignature)proceedingJoinPoint.getSignature();
+		Parameter[] parameters = signature.getMethod().getParameters();
+
+		for (int i = 0; i < parameters.length; i++) {
+			if (parameters[i].getType() == UserPassport.class) {
+				argValues[i] = userPassport;
+				break;
+			}
+		}
+
+		return proceedingJoinPoint.proceed(argValues);
+	}
+}

--- a/application/yabam/src/main/java/com/application/global/authorization/AssignUserPassport.java
+++ b/application/yabam/src/main/java/com/application/global/authorization/AssignUserPassport.java
@@ -1,0 +1,12 @@
+package com.application.global.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AssignUserPassport {
+	boolean required() default true;
+}

--- a/application/yabam/src/main/java/com/application/global/authorization/AssignUserPassport.java
+++ b/application/yabam/src/main/java/com/application/global/authorization/AssignUserPassport.java
@@ -8,5 +8,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AssignUserPassport {
-	boolean required() default true;
 }

--- a/application/yabam/src/main/java/com/application/global/authorization/HasRole.java
+++ b/application/yabam/src/main/java/com/application/global/authorization/HasRole.java
@@ -1,0 +1,14 @@
+package com.application.global.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import domain.pos.member.entity.UserRole;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HasRole {
+	UserRole userRole() default UserRole.ROLE_USER;
+}

--- a/application/yabam/src/main/java/com/application/global/config/WebMvcConfig.java
+++ b/application/yabam/src/main/java/com/application/global/config/WebMvcConfig.java
@@ -1,0 +1,26 @@
+package com.application.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.application.global.interceptor.AuthorizationInterceptor;
+import com.application.global.interceptor.DeserializingUserPassportInterceptor;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final DeserializingUserPassportInterceptor deserializingUserPassportInterceptor;
+	private final AuthorizationInterceptor authorizationInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(deserializingUserPassportInterceptor)
+			.addPathPatterns("/**");
+		registry.addInterceptor(authorizationInterceptor)
+			.addPathPatterns("/**");
+	}
+}

--- a/application/yabam/src/main/java/com/application/global/config/swagger/ApiErrorResponseExplanation.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/ApiErrorResponseExplanation.java
@@ -1,17 +1,14 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.exception.ErrorCode;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ApiResponseExplanations {
-
-	ApiSuccessResponseExplanation success() default @ApiSuccessResponseExplanation();
-
-	ApiErrorResponseExplanation[] errors() default {};
+public @interface ApiErrorResponseExplanation {
+	ErrorCode errorCode();
 }
-

--- a/application/yabam/src/main/java/com/application/global/config/swagger/ApiErrorResponseHandler.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/ApiErrorResponseHandler.java
@@ -1,4 +1,4 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import java.util.Arrays;
 import java.util.List;

--- a/application/yabam/src/main/java/com/application/global/config/swagger/ApiResponseExplanations.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/ApiResponseExplanations.java
@@ -1,14 +1,16 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.exception.ErrorCode;
-
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ApiErrorResponseExplanation {
-	ErrorCode errorCode();
+public @interface ApiResponseExplanations {
+
+	ApiSuccessResponseExplanation success() default @ApiSuccessResponseExplanation();
+
+	ApiErrorResponseExplanation[] errors() default {};
 }
+

--- a/application/yabam/src/main/java/com/application/global/config/swagger/ApiSuccessResponseExplanation.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/ApiSuccessResponseExplanation.java
@@ -1,4 +1,4 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/application/yabam/src/main/java/com/application/global/config/swagger/ApiSuccessResponseHandler.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/ApiSuccessResponseHandler.java
@@ -1,4 +1,4 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;

--- a/application/yabam/src/main/java/com/application/global/config/swagger/SwaggerConfig.java
+++ b/application/yabam/src/main/java/com/application/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.application.config.swagger;
+package com.application.global.config.swagger;
 
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;

--- a/application/yabam/src/main/java/com/application/global/interceptor/AuthorizationInterceptor.java
+++ b/application/yabam/src/main/java/com/application/global/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,40 @@
+package com.application.global.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.application.global.authorization.HasRole;
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.member.entity.UserPassport;
+import domain.pos.member.entity.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		if (handler instanceof HandlerMethod handlerMethod) {
+			HasRole hasRole = handlerMethod.getMethodAnnotation(HasRole.class);
+
+			if (hasRole != null) {
+				UserRole requiredRole = hasRole.userRole();
+				String attributeName = DeserializingUserPassportInterceptor.USER_INFO_ATTRIBUTE;
+
+				UserPassport userPassport = (UserPassport)request.getAttribute(attributeName);
+
+				if (userPassport == null || !userPassport.getUserRole().isHigherOrEqual(requiredRole)) {
+					log.warn("요청 접근 권한이 없습니다. 필요 역할 : {}", requiredRole);
+					throw new ServiceException(ErrorCode.ACCESS_DENIED);
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/application/yabam/src/main/java/com/application/global/interceptor/DeserializingUserPassportInterceptor.java
+++ b/application/yabam/src/main/java/com/application/global/interceptor/DeserializingUserPassportInterceptor.java
@@ -1,0 +1,44 @@
+package com.application.global.interceptor;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import domain.pos.member.entity.UserPassport;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DeserializingUserPassportInterceptor implements HandlerInterceptor {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	public static final String USER_INFO_ATTRIBUTE = "userInfo";
+	public static final String USER_INFO_HEADER = "X-User-Info";
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String userInfoHeader = request.getHeader(USER_INFO_HEADER);
+
+		if (StringUtils.hasText(userInfoHeader)) {
+			try {
+				String decodedUserInfoHeader = URLDecoder.decode(userInfoHeader, StandardCharsets.UTF_8);
+
+				// 역직렬화
+				UserPassport userPassport = objectMapper.readValue(decodedUserInfoHeader, UserPassport.class);
+				request.setAttribute(USER_INFO_ATTRIBUTE, userPassport);
+			} catch (IOException e) {
+				request.setAttribute(USER_INFO_ATTRIBUTE, UserPassport.anonymous());
+			}
+		}
+
+		return true;
+	}
+}

--- a/application/yabam/src/main/resources/application.yml
+++ b/application/yabam/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   application:
-    name:
-      yabam
+    name: yabam
   config:
     activate:
       on-profile: local
@@ -14,8 +13,7 @@ swagger:
 
 spring:
   application:
-    name:
-      yabam
+    name: yabam
   config:
     activate:
       on-profile: dev

--- a/domain/domain-pos/src/main/java/domain/pos/member/entity/UserPassport.java
+++ b/domain/domain-pos/src/main/java/domain/pos/member/entity/UserPassport.java
@@ -14,6 +14,10 @@ public class UserPassport {
 		this.userRole = userRole;
 	}
 
+	public static UserPassport anonymous() {
+		return new UserPassport(null, "Anonymous", UserRole.ROLE_ANONYMOUS);
+	}
+
 	public static UserPassport of(
 		Long userId,
 		String userNickname,

--- a/domain/domain-pos/src/main/java/domain/pos/member/entity/UserRole.java
+++ b/domain/domain-pos/src/main/java/domain/pos/member/entity/UserRole.java
@@ -1,6 +1,11 @@
 package domain.pos.member.entity;
 
 public enum UserRole {
+	ROLE_ANONYMOUS,
 	ROLE_USER,
-	ROLE_OWNER
+	ROLE_OWNER;
+
+	public boolean isHigherOrEqual(UserRole other) {
+		return this.ordinal() >= other.ordinal();
+	}
 }


### PR DESCRIPTION
1️⃣ (Gateway) JWT 복호화를 통해 얻는 유저정보를 하나의 헤더값에 Json으로 삽입하도록 수정
---
- 기존에 userId는 userId 헤더값, userRole은 userRole 헤더값에 따로따로 저장하던 방식에서, 하나의 헤더값에 모든 유저 정보를 삽입하도록 변경

2️⃣ (Yabam) 헤더값 유저정보 Json을 UserPassport 클래스 객체로 역직렬화하는 인터셉터 구현
---
- 인터셉터 중 첫 번째 순서의 인터셉터
- 역직렬화 결과 객체를 요청의 Attribute에 삽입한다.
- 유저정보 헤더값이 존재하지않으면, 익명유저 UserPassport로 변환

3️⃣(Yabam) 엔드포인트 호출 유저 필요 권한을 설정하는 HasRole 어노테이션 및 내부 로직 담당 인터셉터 구현
---
- 어노테이션 value로 설정하는 역할 이상을 요청 유저가 지녀야 성공적으로 요청을 할 수 있도록 설정
- value를 설정하지 않으면, ROLE_USER가 기본 조건으로 삽입됨

4️⃣ (Yabam) 컨트롤러 매개변수에 UserPassport 삽입 담당 AssignUserPassport 어노테이션 및 내부 로직 담당 AOP 구현
---
- attribute에 삽입된 UserPassport 객체를 컨트롤러 매개변수에 삽입

✔️ 어노테이션 사용 방법
--- 
- ![image](https://github.com/user-attachments/assets/73201a73-4f22-486e-bb7a-93f1233bbe58)
- HasRole 어노테이션 : 엔드포인트 접근 권한 설정
- AssignUserPassport 어노테이션 : 매개변수에 선언된 UserPassport 매개변수에 역직렬화 된 유저정보 삽입