### PR TITLE
Table 도메인 엔티티 설계 및 테이블 생성 로직 구현

### DIFF
--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -36,7 +36,10 @@ public enum ErrorCode {
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "SECURITY_0002", "권한이 없습니다."),
 	JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "SECURITY_0003", "JWT 토큰이 만료되었습니다."),
 	JWT_INVALID(HttpStatus.UNAUTHORIZED, "SECURITY_0004", "JWT 토큰이 올바르지 않습니다."),
-	JWT_NOT_EXIST(HttpStatus.UNAUTHORIZED, "SECURITY_0005", "JWT 토큰이 존재하지 않습니다.");
+	JWT_NOT_EXIST(HttpStatus.UNAUTHORIZED, "SECURITY_0005", "JWT 토큰이 존재하지 않습니다."),
+
+	// Table
+	EXIST_TABLE(HttpStatus.CONFLICT, "TABLE_0001", "이미 존재하는 테이블입니다");
 
 	private final HttpStatus status;
 	private final String code;

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -25,7 +25,7 @@ public class StoreValidator {
 		}
 	}
 
-	public Store validateStoreModifyByUser(UserPassport userPassport, Long queryStoreId) {
+	public Store validateStoreByUser(UserPassport userPassport, Long queryStoreId) {
 		if (isOwner(userPassport)) {
 			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
 			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -6,7 +6,6 @@ import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
 import domain.pos.member.entity.UserPassport;
-import domain.pos.member.entity.UserRole;
 import domain.pos.store.entity.Store;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,27 +24,18 @@ public class StoreValidator {
 		}
 	}
 
-	public Store validateStoreByUser(UserPassport userPassport, Long queryStoreId) {
-		if (isOwner(userPassport)) {
-			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
-			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
-		}
+	public Store validateStoreOwner(UserPassport ownerPassport, Long queryStoreId) {
 		final Store previousStore = storeReader.readSingleStore(queryStoreId)
 			.orElseThrow(() -> {
 				log.warn("해당 Store 존재하지 않음: storeId={}", queryStoreId);
 				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
 			});
 
-		if (isEqualSavedStoreOwnerAndQueryOwner(userPassport.getUserId(), previousStore)) {
-			log.warn("요청 유저는 Store 소유자와 다름: userId={}, queryStoreId={}", userPassport.getUserId(), queryStoreId);
+		if (isEqualSavedStoreOwnerAndQueryOwner(ownerPassport.getUserId(), previousStore)) {
+			log.warn("요청 유저는 Store 소유자와 다름: userId={}, queryStoreId={}", ownerPassport.getUserId(), queryStoreId);
 			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
 		}
 		return previousStore;
-	}
-
-	// 점주가 아닌 사용자인지 확인
-	private boolean isOwner(UserPassport userPassport) {
-		return !userPassport.getUserRole().equals(UserRole.ROLE_OWNER);
 	}
 
 	// 가게 소유자와 요청 점주가 같은지 확인

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
@@ -28,7 +28,7 @@ public class SaleService {
 
 	@Transactional
 	public Sale openStore(final UserPassport userPassport, final Long storeId) {
-		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, storeId);
+		final Store previousStore = storeValidator.validateStoreByUser(userPassport, storeId);
 
 		if (previousStore.getIsOpen()) {
 			log.warn("가게 활성화 변경 실패: userId={}, storeId={}", userPassport.getUserId(), storeId);

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
@@ -7,7 +7,6 @@ import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
 import domain.pos.member.entity.UserPassport;
-import domain.pos.member.entity.UserRole;
 import domain.pos.store.entity.Sale;
 import domain.pos.store.entity.Store;
 import domain.pos.store.implement.SaleReader;
@@ -27,60 +26,51 @@ public class SaleService {
 	private final StoreValidator storeValidator;
 
 	@Transactional
-	public Sale openStore(final UserPassport userPassport, final Long storeId) {
-		final Store previousStore = storeValidator.validateStoreByUser(userPassport, storeId);
+	public Sale openStore(final UserPassport ownerPassport, final Long storeId) {
+		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, storeId);
 
 		if (previousStore.getIsOpen()) {
-			log.warn("가게 활성화 변경 실패: userId={}, storeId={}", userPassport.getUserId(), storeId);
+			log.warn("가게 활성화 변경 실패: userId={}, storeId={}", ownerPassport.getUserId(), storeId);
 			throw new ServiceException(ErrorCode.CONFLICT_OPEN_STORE);
 		}
 
 		final Store opendStore = storeWriter.modifyStoreOpenStatus(previousStore);
 		final Sale createdSale = saleWriter.createSale(opendStore);
 
-		log.info("가게 활성화 성공 : userId={}, storeId={}, saleId={}", userPassport.getUserId(), storeId,
+		log.info("가게 활성화 성공 : userId={}, storeId={}, saleId={}", ownerPassport.getUserId(), storeId,
 			createdSale.getSaleId());
 		return createdSale;
 	}
 
 	@Transactional
-	public Sale closeStore(final UserPassport userPassport, final Long saleId) {
-		if (isOwner(userPassport)) {
-			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
-			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
-		}
+	public Sale closeStore(final UserPassport ownerPassport, final Long saleId) {
 		final Sale savedSale = saleReader.readSingleSale(saleId)
 			.orElseThrow(() -> {
 				log.warn("판매 내역 조회 실패: saleId={}", saleId);
 				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
 			});
 
-		validateOpendSaleOrStore(userPassport, saleId, savedSale);
+		validateOpendSaleOrStore(ownerPassport, saleId, savedSale);
 
 		final Store closedStore = storeWriter.modifyStoreOpenStatus(savedSale.getStore());
 		final Sale closedSale = saleWriter.closeSale(savedSale, closedStore);
-		log.info("가게 종료 성공 : userId={}, storeId={}, saleId={}", userPassport.getUserId(),
+		log.info("가게 종료 성공 : userId={}, storeId={}, saleId={}", ownerPassport.getUserId(),
 			savedSale.getStore().getStoreId(), closedSale.getSaleId());
 		return closedSale;
 	}
 
 	// 판매 종료 시점에 가게가 종료된 상태인지 확인
-	private static void validateOpendSaleOrStore(UserPassport userPassport, Long saleId, Sale savedSale) {
+	private static void validateOpendSaleOrStore(UserPassport ownerPassport, Long saleId, Sale savedSale) {
 		savedSale.getCloseDateTime()
 			.ifPresent((dateTime) -> {
-				log.warn("이미 종료된 Sale.: userId={}, saleId={}", userPassport.getUserId(), saleId);
+				log.warn("이미 종료된 Sale.: userId={}, saleId={}", ownerPassport.getUserId(), saleId);
 				throw new ServiceException(ErrorCode.CONFLICT_CLOSE_STORE);
 			});
 		if (!savedSale.getStore().getIsOpen()) {
-			log.warn("이미 종료된 가게 상태: userId={}, storeId={}", userPassport.getUserId(),
+			log.warn("이미 종료된 가게 상태: userId={}, storeId={}", ownerPassport.getUserId(),
 				savedSale.getStore().getStoreId());
 			throw new ServiceException(ErrorCode.CONFLICT_CLOSE_STORE);
 		}
-	}
-
-	// 점주가 아닌 사용자인지 확인
-	private boolean isOwner(UserPassport userPassport) {
-		return !userPassport.getUserRole().equals(UserRole.ROLE_OWNER);
 	}
 
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -53,7 +53,7 @@ public class StoreService {
 		final Long queryStoreId,
 		final StoreInfo requestChangeStoreInfo) {
 
-		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, queryStoreId);
+		final Store previousStore = storeValidator.validateStoreByUser(userPassport, queryStoreId);
 		Store updatedStore = storeWriter
 			.updateStoreInfo(previousStore, requestChangeStoreInfo);
 		log.info("가게 정보 수정 성공 : userId={}, storeId={}", userPassport.getUserId(), queryStoreId);
@@ -62,7 +62,7 @@ public class StoreService {
 	}
 
 	public void deleteStore(final UserPassport userPassport, final Long storeId) {
-		final Store previousStore = storeValidator.validateStoreModifyByUser(userPassport, storeId);
+		final Store previousStore = storeValidator.validateStoreByUser(userPassport, storeId);
 		storeWriter.deleteStore(previousStore);
 		log.info("가게 삭제 성공 : userId={}, storeId={}", userPassport.getUserId(), storeId);
 	}

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -6,7 +6,6 @@ import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
 import domain.pos.member.entity.UserPassport;
-import domain.pos.member.entity.UserRole;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
 import domain.pos.store.implement.StoreReader;
@@ -23,20 +22,10 @@ public class StoreService {
 	private final StoreReader storeReader;
 	private final StoreValidator storeValidator;
 
-	public Long createStore(final UserPassport userPassport, final StoreInfo createRequestStoreInfo) {
-		if (isOwner(userPassport)) {
-			log.warn("점주가 아닌 사용자의 요청으로 인한 실패: userId={}", userPassport.getUserId());
-			throw new ServiceException(ErrorCode.NOT_VALID_OWNER);
-		}
-
-		final Long savedStoreId = storeWriter.createStore(userPassport, createRequestStoreInfo);
-		log.info("가게 생성 성공 : userId={}, storeId={}", userPassport.getUserId(), savedStoreId);
+	public Long createStore(final UserPassport ownerPassport, final StoreInfo createRequestStoreInfo) {
+		final Long savedStoreId = storeWriter.createStore(ownerPassport, createRequestStoreInfo);
+		log.info("가게 생성 성공 : userId={}, storeId={}", ownerPassport.getUserId(), savedStoreId);
 		return savedStoreId;
-	}
-
-	// 점주가 아닌 사용자인지 확인
-	private boolean isOwner(UserPassport userPassport) {
-		return !userPassport.getUserRole().equals(UserRole.ROLE_OWNER);
 	}
 
 	public Store findStore(final Long storeId) {
@@ -49,21 +38,21 @@ public class StoreService {
 	}
 
 	public Store updateStoreInfo(
-		final UserPassport userPassport,
+		final UserPassport ownerPassport,
 		final Long queryStoreId,
 		final StoreInfo requestChangeStoreInfo) {
 
-		final Store previousStore = storeValidator.validateStoreByUser(userPassport, queryStoreId);
+		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, queryStoreId);
 		Store updatedStore = storeWriter
 			.updateStoreInfo(previousStore, requestChangeStoreInfo);
-		log.info("가게 정보 수정 성공 : userId={}, storeId={}", userPassport.getUserId(), queryStoreId);
+		log.info("가게 정보 수정 성공 : userId={}, storeId={}", ownerPassport.getUserId(), queryStoreId);
 
 		return updatedStore;
 	}
 
-	public void deleteStore(final UserPassport userPassport, final Long storeId) {
-		final Store previousStore = storeValidator.validateStoreByUser(userPassport, storeId);
+	public void deleteStore(final UserPassport ownerPassport, final Long storeId) {
+		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, storeId);
 		storeWriter.deleteStore(previousStore);
-		log.info("가게 삭제 성공 : userId={}, storeId={}", userPassport.getUserId(), storeId);
+		log.info("가게 삭제 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/entity/Table.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/entity/Table.java
@@ -10,10 +10,19 @@ public class Table {
 	private final Boolean isActive;
 	private final Store store;
 
-	public Table(Long tableId, Integer tableNumber, Boolean isActive, Store store) {
+	private Table(Long tableId, Integer tableNumber, Boolean isActive, Store store) {
 		this.tableId = tableId;
 		this.tableNumber = tableNumber;
 		this.isActive = isActive;
 		this.store = store;
+	}
+
+	public static Table of(Long tableId, Integer tableNumber, Boolean isActive, Store store) {
+		return new Table(
+			tableId,
+			tableNumber,
+			isActive,
+			store
+		);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/entity/Table.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/entity/Table.java
@@ -1,4 +1,19 @@
 package domain.pos.table.entity;
 
+import domain.pos.store.entity.Store;
+import lombok.Getter;
+
+@Getter
 public class Table {
+	private final Long tableId; // 테이블 고유 ID TODO : 해당 값을 UUID로 하여 QR 코드 인식시 사용할지 고민
+	private final Integer tableNumber;
+	private final Boolean isActive;
+	private final Store store;
+
+	public Table(Long tableId, Integer tableNumber, Boolean isActive, Store store) {
+		this.tableId = tableId;
+		this.tableNumber = tableNumber;
+		this.isActive = isActive;
+		this.store = store;
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/implement/TableHandler.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/implement/TableHandler.java
@@ -18,7 +18,7 @@ public class TableHandler {
 		return tableRepository.createTable(responStore, queryTableNumber);
 	}
 
-	public Optional<Object> exitsTable(Store responStore, Integer queryTableNumber) {
+	public Optional<Object> existsTable(Store responStore, Integer queryTableNumber) {
 		return tableRepository.findTableByStoreAndTableNum(responStore, queryTableNumber);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/implement/TableHandler.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/implement/TableHandler.java
@@ -1,4 +1,24 @@
 package domain.pos.table.implement;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.store.entity.Store;
+import domain.pos.table.entity.Table;
+import domain.pos.table.repository.TableRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class TableHandler {
+	private final TableRepository tableRepository;
+
+	public Table createTable(Store responStore, Integer queryTableNumber) {
+		return tableRepository.createTable(responStore, queryTableNumber);
+	}
+
+	public Optional<Object> exitsTable(Store responStore, Integer queryTableNumber) {
+		return tableRepository.findTableByStoreAndTableNum(responStore, queryTableNumber);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/repository/TableRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/repository/TableRepository.java
@@ -1,4 +1,12 @@
 package domain.pos.table.repository;
 
-public class TableRepository {
+import java.util.Optional;
+
+import domain.pos.store.entity.Store;
+import domain.pos.table.entity.Table;
+
+public interface TableRepository {
+	Table createTable(Store responStore, Integer queryTableNumber);
+
+	Optional<Object> findTableByStoreAndTableNum(Store responStore, Integer queryTableNumber);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
@@ -24,7 +24,7 @@ public class TableService {
 		final Integer queryTableNumber) {
 		final Store store = storeValidator.validateStoreOwner(ownerPassport, queryStoreId);
 
-		tableHandler.exitsTable(store, queryTableNumber)
+		tableHandler.existsTable(store, queryTableNumber)
 			.ifPresent(table -> {
 				log.warn("존재하는 테이블 생성 에러 : storeId={}, tableNumber={}", queryStoreId, queryTableNumber);
 				throw new ServiceException(ErrorCode.EXIST_TABLE);

--- a/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
@@ -20,9 +20,9 @@ public class TableService {
 	private final StoreValidator storeValidator;
 	private final TableHandler tableHandler;
 
-	public Table createTable(final UserPassport queryUserPassport, final Long queryStoreId,
+	public Table createTable(final UserPassport ownerPassport, final Long queryStoreId,
 		final Integer queryTableNumber) {
-		final Store store = storeValidator.validateStoreByUser(queryUserPassport, queryStoreId);
+		final Store store = storeValidator.validateStoreOwner(ownerPassport, queryStoreId);
 
 		tableHandler.exitsTable(store, queryTableNumber)
 			.ifPresent(table -> {

--- a/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/table/service/TableService.java
@@ -1,4 +1,36 @@
 package domain.pos.table.service;
 
+import org.springframework.stereotype.Service;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.member.entity.UserPassport;
+import domain.pos.store.entity.Store;
+import domain.pos.store.implement.StoreValidator;
+import domain.pos.table.entity.Table;
+import domain.pos.table.implement.TableHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
 public class TableService {
+	private final StoreValidator storeValidator;
+	private final TableHandler tableHandler;
+
+	public Table createTable(final UserPassport queryUserPassport, final Long queryStoreId,
+		final Integer queryTableNumber) {
+		final Store store = storeValidator.validateStoreByUser(queryUserPassport, queryStoreId);
+
+		tableHandler.exitsTable(store, queryTableNumber)
+			.ifPresent(table -> {
+				log.warn("존재하는 테이블 생성 에러 : storeId={}, tableNumber={}", queryStoreId, queryTableNumber);
+				throw new ServiceException(ErrorCode.EXIST_TABLE);
+			});
+		final Table createdTable = tableHandler.createTable(store, queryTableNumber);
+		log.info("테이블 생성 성공 : storeId={}, tableNumber={}", queryStoreId, queryTableNumber);
+		return createdTable;
+	}
 }

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
@@ -55,7 +55,7 @@ class SaleServiceTest extends ServiceTest {
 			Sale createdSale = GENERAL_OPEN_SALE(opendStore);
 
 			doReturn(savedStore)
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 			doReturn(opendStore)
 				.when(storeWriter).modifyStoreOpenStatus(savedStore);
 			doReturn(createdSale)
@@ -69,7 +69,7 @@ class SaleServiceTest extends ServiceTest {
 				softly.assertThat(result.getStore().getIsOpen()).isTrue();
 
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+					.validateStoreByUser(any(UserPassport.class), anyLong());
 				verify(storeWriter)
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter)
@@ -84,7 +84,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -92,7 +92,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.NOT_VALID_OWNER.getMessage());
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+					.validateStoreByUser(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -108,7 +108,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -116,7 +116,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.NOT_FOUND_STORE.getMessage());
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+					.validateStoreByUser(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -131,7 +131,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -139,7 +139,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.NOT_EQUAL_STORE_OWNER.getMessage());
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+					.validateStoreByUser(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -155,7 +155,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = savedStore.getStoreId();
 
 			doReturn(savedStore)
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -163,7 +163,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.CONFLICT_OPEN_STORE.getMessage());
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), anyLong());
+					.validateStoreByUser(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/SaleServiceTest.java
@@ -55,7 +55,7 @@ class SaleServiceTest extends ServiceTest {
 			Sale createdSale = GENERAL_OPEN_SALE(opendStore);
 
 			doReturn(savedStore)
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 			doReturn(opendStore)
 				.when(storeWriter).modifyStoreOpenStatus(savedStore);
 			doReturn(createdSale)
@@ -69,36 +69,12 @@ class SaleServiceTest extends ServiceTest {
 				softly.assertThat(result.getStore().getIsOpen()).isTrue();
 
 				verify(storeValidator)
-					.validateStoreByUser(any(UserPassport.class), anyLong());
+					.validateStoreOwner(any(UserPassport.class), anyLong());
 				verify(storeWriter)
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter)
 					.createSale(any(Store.class));
 			});
-		}
-
-		@Test
-		void 실패_요청_유저가_점주가_아닐때() {
-			// given
-			UserPassport queryUserPassport = GENERAL_USER_PASSPORT();
-			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
-
-			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
-
-			// when->then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(() -> saleService.openStore(queryUserPassport, queryStoreId))
-					.isInstanceOf(ServiceException.class)
-					.hasMessage(ErrorCode.NOT_VALID_OWNER.getMessage());
-				verify(storeValidator)
-					.validateStoreByUser(any(UserPassport.class), anyLong());
-				verify(storeWriter, never())
-					.modifyStoreOpenStatus(any(Store.class));
-				verify(saleWriter, never())
-					.createSale(any(Store.class));
-			});
-
 		}
 
 		@Test
@@ -108,7 +84,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -116,7 +92,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.NOT_FOUND_STORE.getMessage());
 				verify(storeValidator)
-					.validateStoreByUser(any(UserPassport.class), anyLong());
+					.validateStoreOwner(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -131,7 +107,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_USER_PASSPORT().getUserId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -139,7 +115,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.NOT_EQUAL_STORE_OWNER.getMessage());
 				verify(storeValidator)
-					.validateStoreByUser(any(UserPassport.class), anyLong());
+					.validateStoreOwner(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -155,7 +131,7 @@ class SaleServiceTest extends ServiceTest {
 			Long queryStoreId = savedStore.getStoreId();
 
 			doReturn(savedStore)
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 
 			// when->then
 			assertSoftly(softly -> {
@@ -163,7 +139,7 @@ class SaleServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasMessage(ErrorCode.CONFLICT_OPEN_STORE.getMessage());
 				verify(storeValidator)
-					.validateStoreByUser(any(UserPassport.class), anyLong());
+					.validateStoreOwner(any(UserPassport.class), anyLong());
 				verify(storeWriter, never())
 					.modifyStoreOpenStatus(any(Store.class));
 				verify(saleWriter, never())
@@ -209,25 +185,6 @@ class SaleServiceTest extends ServiceTest {
 					.closeSale(any(Sale.class), any(Store.class));
 			});
 
-		}
-
-		@Test
-		void 실패_점주가_아닌_USER() {
-			// given
-			UserPassport queryUserPassport = GENERAL_USER_PASSPORT();
-
-			// when->then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(() -> saleService.closeStore(queryUserPassport, 1L))
-					.isInstanceOf(ServiceException.class)
-					.hasMessage(ErrorCode.NOT_VALID_OWNER.getMessage());
-				verify(saleReader, never())
-					.readSingleSale(anyLong());
-				verify(storeWriter, never())
-					.modifyStoreOpenStatus(any(Store.class));
-				verify(saleWriter, never())
-					.closeSale(any(Sale.class), any(Store.class));
-			});
 		}
 
 		@Test

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
@@ -139,7 +139,7 @@ class StoreServiceTest extends ServiceTest {
 			Store changedStore = CHANGED_GENERAL_STORE();
 
 			doReturn(nonChangedStore)
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 			doReturn(changedStore)
 				.when(storeWriter).updateStoreInfo(nonChangedStore, requestChangeStoreInfo);
 
@@ -153,7 +153,7 @@ class StoreServiceTest extends ServiceTest {
 			assertSoftly(softly -> {
 				softly.assertThat(result.getStoreId()).isEqualTo(changedStore.getStoreId());
 
-				verify(storeValidator).validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+				verify(storeValidator).validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter).updateStoreInfo(any(Store.class), any(StoreInfo.class));
 			});
 		}
@@ -166,7 +166,7 @@ class StoreServiceTest extends ServiceTest {
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 
 			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			//when -> then
 			assertSoftly(softly -> {
@@ -178,7 +178,7 @@ class StoreServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_VALID_OWNER);
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 
 				verify(storeWriter, never())
 					.updateStoreInfo(any(Store.class), any(StoreInfo.class));
@@ -194,7 +194,7 @@ class StoreServiceTest extends ServiceTest {
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 
 			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(diffOwnerUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(diffOwnerUserPassport, queryStoreId);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -205,7 +205,7 @@ class StoreServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter, never())
 					.updateStoreInfo(any(Store.class), any(StoreInfo.class));
 			});
@@ -220,7 +220,7 @@ class StoreServiceTest extends ServiceTest {
 			StoreInfo requestChangeStoreInfo = CHANGED_GENERAL_STORE().getStoreInfo();
 
 			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
-				.when(storeValidator).validateStoreModifyByUser(queryOwnerPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryOwnerPassport, queryStoreId);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -233,7 +233,7 @@ class StoreServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
 
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter, never())
 					.updateStoreInfo(any(Store.class), any(StoreInfo.class));
 			});
@@ -251,7 +251,7 @@ class StoreServiceTest extends ServiceTest {
 			Store savedStore = GENERAL_STORE();
 
 			doReturn(savedStore)
-				.when(storeValidator).validateStoreModifyByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
 
 			// when
 			storeService.deleteStore(queryUserPassport, queryStoreId);
@@ -259,7 +259,7 @@ class StoreServiceTest extends ServiceTest {
 			// then
 			assertSoftly(softly -> {
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter)
 					.deleteStore(any(Store.class));
 			});
@@ -272,7 +272,7 @@ class StoreServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_VALID_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(queryOwnerPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryOwnerPassport, queryStoreId);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -281,7 +281,7 @@ class StoreServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_VALID_OWNER);
 
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter, never())
 					.deleteStore(any(Store.class));
 			});
@@ -294,7 +294,7 @@ class StoreServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
-				.when(storeValidator).validateStoreModifyByUser(queryOwnerPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryOwnerPassport, queryStoreId);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -303,7 +303,7 @@ class StoreServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
 
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter, never())
 					.deleteStore(any(Store.class));
 			});
@@ -316,7 +316,7 @@ class StoreServiceTest extends ServiceTest {
 			Long queryStoreId = GENERAL_STORE().getStoreId();
 
 			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
-				.when(storeValidator).validateStoreModifyByUser(queryDiffOwnerPassport, queryStoreId);
+				.when(storeValidator).validateStoreByUser(queryDiffOwnerPassport, queryStoreId);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -325,7 +325,7 @@ class StoreServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
 
 				verify(storeValidator)
-					.validateStoreModifyByUser(any(UserPassport.class), any(Long.class));
+					.validateStoreByUser(any(UserPassport.class), any(Long.class));
 				verify(storeWriter, never())
 					.deleteStore(any(Store.class));
 			});

--- a/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
@@ -1,0 +1,103 @@
+package domain.pos.table.service;
+
+import static fixtures.member.UserFixture.*;
+import static fixtures.store.StoreFixture.*;
+import static fixtures.table.TableFixture.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import base.ServiceTest;
+import domain.pos.member.entity.UserPassport;
+import domain.pos.store.entity.Store;
+import domain.pos.store.implement.StoreValidator;
+import domain.pos.table.entity.Table;
+import domain.pos.table.implement.TableHandler;
+
+class TableServiceTest extends ServiceTest {
+
+	@Mock
+	private StoreValidator storeValidator;
+
+	@Mock
+	private TableHandler tableHandler;
+
+	@InjectMocks
+	private TableService tableService;
+
+	@Nested
+	@DisplayName("가게 테이블 생성")
+	class createTable {
+		@Test
+		void 성공() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_STORE().getStoreId();
+			Integer queryTableNumber = 1;
+
+			Store responStore = GENERAL_STORE();
+			Table createdTable = GENERAL_IN_ACTIVE_TABLE(responStore);
+
+			doReturn(responStore)
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+			doReturn(Optional.empty())
+				.when(tableHandler).exitsTable(responStore, queryTableNumber);
+			doReturn(createdTable)
+				.when(tableHandler).createTable(responStore, queryTableNumber);
+			// when
+			Table resultTable = tableService.createTable(queryUserPassport, queryStoreId, queryTableNumber);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(resultTable.getTableId()).isEqualTo(createdTable.getTableId());
+				softly.assertThat(resultTable.getTableNumber()).isEqualTo(createdTable.getTableNumber());
+				softly.assertThat(resultTable.getStore().getStoreId()).isEqualTo(responStore.getStoreId());
+				softly.assertThat(resultTable.getStore().getStoreId()).isEqualTo(responStore.getStoreId());
+
+				verify(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				verify(tableHandler).createTable(responStore, queryTableNumber);
+			});
+		}
+
+		@Test
+		void 실패_존재하는_테이블() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_STORE().getStoreId();
+			Integer queryTableNumber = GENERAL_IN_ACTIVE_TABLE(GENERAL_STORE()).getTableNumber();
+
+			Store responStore = GENERAL_STORE();
+			Table createdTable = GENERAL_IN_ACTIVE_TABLE(responStore);
+
+			doReturn(responStore)
+				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+			doReturn(Optional.of(createdTable))
+				.when(tableHandler).exitsTable(responStore, queryTableNumber);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> tableService.createTable(queryUserPassport, queryStoreId, queryTableNumber))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXIST_TABLE);
+
+				verify(storeValidator)
+					.validateStoreByUser(queryUserPassport, queryStoreId);
+				verify(tableHandler)
+					.exitsTable(responStore, queryTableNumber);
+				verify(tableHandler, never())
+					.createTable(responStore, queryTableNumber);
+			});
+		}
+	}
+}

--- a/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
@@ -51,7 +51,7 @@ class TableServiceTest extends ServiceTest {
 			doReturn(responStore)
 				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 			doReturn(Optional.empty())
-				.when(tableHandler).exitsTable(responStore, queryTableNumber);
+				.when(tableHandler).existsTable(responStore, queryTableNumber);
 			doReturn(createdTable)
 				.when(tableHandler).createTable(responStore, queryTableNumber);
 			// when
@@ -89,7 +89,7 @@ class TableServiceTest extends ServiceTest {
 				verify(storeValidator)
 					.validateStoreOwner(queryUserPassport, queryStoreId);
 				verify(tableHandler, never())
-					.exitsTable(any(Store.class), anyInt());
+					.existsTable(any(Store.class), anyInt());
 				verify(tableHandler, never())
 					.createTable(any(Store.class), anyInt());
 			});
@@ -115,7 +115,7 @@ class TableServiceTest extends ServiceTest {
 				verify(storeValidator)
 					.validateStoreOwner(queryUserPassport, queryStoreId);
 				verify(tableHandler, never())
-					.exitsTable(any(Store.class), anyInt());
+					.existsTable(any(Store.class), anyInt());
 				verify(tableHandler, never())
 					.createTable(any(Store.class), anyInt());
 			});
@@ -134,7 +134,7 @@ class TableServiceTest extends ServiceTest {
 			doReturn(responStore)
 				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 			doReturn(Optional.of(createdTable))
-				.when(tableHandler).exitsTable(responStore, queryTableNumber);
+				.when(tableHandler).existsTable(responStore, queryTableNumber);
 
 			// when -> then
 			assertSoftly(softly -> {
@@ -146,7 +146,7 @@ class TableServiceTest extends ServiceTest {
 				verify(storeValidator)
 					.validateStoreOwner(queryUserPassport, queryStoreId);
 				verify(tableHandler)
-					.exitsTable(responStore, queryTableNumber);
+					.existsTable(responStore, queryTableNumber);
 				verify(tableHandler, never())
 					.createTable(responStore, queryTableNumber);
 			});

--- a/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/table/service/TableServiceTest.java
@@ -49,7 +49,7 @@ class TableServiceTest extends ServiceTest {
 			Table createdTable = GENERAL_IN_ACTIVE_TABLE(responStore);
 
 			doReturn(responStore)
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 			doReturn(Optional.empty())
 				.when(tableHandler).exitsTable(responStore, queryTableNumber);
 			doReturn(createdTable)
@@ -64,7 +64,7 @@ class TableServiceTest extends ServiceTest {
 				softly.assertThat(resultTable.getStore().getStoreId()).isEqualTo(responStore.getStoreId());
 				softly.assertThat(resultTable.getStore().getStoreId()).isEqualTo(responStore.getStoreId());
 
-				verify(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				verify(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 				verify(tableHandler).createTable(responStore, queryTableNumber);
 			});
 		}
@@ -80,7 +80,7 @@ class TableServiceTest extends ServiceTest {
 			Table createdTable = GENERAL_IN_ACTIVE_TABLE(responStore);
 
 			doReturn(responStore)
-				.when(storeValidator).validateStoreByUser(queryUserPassport, queryStoreId);
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
 			doReturn(Optional.of(createdTable))
 				.when(tableHandler).exitsTable(responStore, queryTableNumber);
 
@@ -92,7 +92,7 @@ class TableServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXIST_TABLE);
 
 				verify(storeValidator)
-					.validateStoreByUser(queryUserPassport, queryStoreId);
+					.validateStoreOwner(queryUserPassport, queryStoreId);
 				verify(tableHandler)
 					.exitsTable(responStore, queryTableNumber);
 				verify(tableHandler, never())

--- a/domain/domain-pos/src/test/java/fixtures/table/TableFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/table/TableFixture.java
@@ -1,0 +1,26 @@
+package fixtures.table;
+
+import domain.pos.store.entity.Store;
+import domain.pos.table.entity.Table;
+
+public class TableFixture {
+	// 테이블 고유 ID
+	private static final Long GENERAL_TABLE_ID = 1L;
+
+	// 테이블 번호
+	private static final Integer GENERAL_TABLE_NUMBER = 1;
+
+	// 테이블 활성화 여부
+	private static final Boolean IS_ACTIVE = true;
+	private static final Boolean IS_INACTIVE = false;
+
+	public static Table GENERAL_IN_ACTIVE_TABLE(Store store) {
+		return Table.of(
+			GENERAL_TABLE_ID,
+			GENERAL_TABLE_NUMBER,
+			IS_INACTIVE,
+			store
+		);
+	}
+
+}

--- a/rule-config/naver-checkstyle-rules.xml
+++ b/rule-config/naver-checkstyle-rules.xml
@@ -56,12 +56,12 @@ The following rules in the Naver coding convention cannot be checked by this con
 
         <!-- [list-uppercase-abbr] -->
         <module name="AbbreviationAsWordInName">
-            <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="1"/>
-            <message key="abbreviation.as.word"
-                     value="[list-uppercase-abbr] Abbreviation in name ''{0}'' must contain no more than {1}"/>
-            <property name="allowedAbbreviations" value="DAO,BO"/>
+            <property name="ignoreStatic" value="true"/>
+            <property name="ignoreFinal" value="true"/>
+            <property name="allowedAbbreviationLength" value="20"/>
+            <property name="allowedAbbreviations" value="DAO,BO,USER_ID,USER_NICKNAME,USER_ROLE,USER_INFO_HEADER"/>
         </module>
+
 
         <!-- [package-lowercase] -->
         <module name="PackageName">
@@ -86,10 +86,9 @@ The following rules in the Naver coding convention cannot be checked by this con
 
         <!-- [var-lower-camelcase] -->
         <module name="MemberName">
-            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
-            <message key="name.invalidPattern"
-                     value="[var-lower-camelcase] Member name ''{0}'' must match pattern ''{1}''."/>
+            <property name="format" value="^[a-zA-Z_][a-zA-Z0-9_]*$"/>
         </module>
+
         <module name="ParameterName">
             <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"


### PR DESCRIPTION

## 🍀 작업사항

### 1️⃣ Table 엔티티 설계

```java

public class Table {
	private final Long tableId; // 테이블 고유 ID TODO : 해당 값을 UUID로 하여 QR 코드 인식시 사용할지 고민
	private final Integer tableNumber;
	private final Boolean isActive;
	private final Store store;
}

```


### 2️⃣ Table 생성 로직 구현

```mermaid
graph TD

CreateTable["[유스케이스] 테이블 생성"] --> ValidateStore["Store 유효성 검사"]
ValidateStore -->|가게 없음| Error1["❌ NOT_FOUND_STORE"]
ValidateStore -->|요청자 ≠ 소유자| Error2["❌ NOT_EQUAL_STORE_OWNER"]

CreateTable --> CheckTableExists["해당 번호의 테이블 존재 여부 확인"]
CheckTableExists -->|존재함| Error3["❌ EXIST_TABLE"]

CheckTableExists -->|존재하지 않음| Success["✅ 테이블 생성 완료"]


```

## ❓ 리뷰 포인트

- 권한 설정하는 validation 코드를 전부 제거했습니다. 그런데 StoreValidator의   validateStoreOwner 가 중복되어서 일단 오버로딩 형태로 남겨놨습니다. 해당 메서드 리팩터링 필요해보입니다 어떻게 할까요