### PR TITLE
메뉴 수정/삭제 도메인 로직 구현

### DIFF
--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategory.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategory.java
@@ -7,10 +7,12 @@ import lombok.Getter;
 public class MenuCategory {
 	private Long menuCategoryId;
 	private String menuCategoryName;
+	private Long storeId;
 
 	@Builder
-	public MenuCategory(Long menuCategoryId, String menuCategoryName) {
+	public MenuCategory(Long menuCategoryId, String menuCategoryName, Long storeId) {
 		this.menuCategoryId = menuCategoryId;
 		this.menuCategoryName = menuCategoryName;
+		this.storeId = storeId;
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryReader.java
@@ -1,5 +1,6 @@
 package domain.pos.menu.implement;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -15,5 +16,9 @@ public class MenuCategoryReader {
 
 	public Optional<MenuCategory> getMenuCategory(Long categoryId) {
 		return menuCategoryRepository.getMenuCategory(categoryId);
+	}
+
+	public List<MenuCategory> getMenuCategoryList(Long storeId) {
+		return menuCategoryRepository.getMenuCategoryList(storeId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuCategoryWriter.java
@@ -11,7 +11,16 @@ import lombok.RequiredArgsConstructor;
 public class MenuCategoryWriter {
 	private final MenuCategoryRepository menuCategoryRepository;
 
-	public MenuCategory postMenuCategory(String categoryName) {
-		return menuCategoryRepository.postMenuCategory(categoryName);
+	public MenuCategory postMenuCategory(Long storeId, String categoryName) {
+		return menuCategoryRepository.postMenuCategory(storeId, categoryName);
 	}
+
+	public MenuCategory patchMenuCategory(Long categoryId, String categoryName) {
+		return menuCategoryRepository.patchMenuCategory(categoryId, categoryName);
+	}
+
+	public void deleteMenuCategory(Long categoryId) {
+		menuCategoryRepository.deleteMenuCategory(categoryId);
+	}
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuValidator.java
@@ -1,0 +1,19 @@
+package domain.pos.menu.implement;
+
+import org.springframework.stereotype.Component;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MenuValidator {
+	private final MenuReader menuReader;
+	
+	public void validateMenu(Long menuId) {
+		menuReader.getMenuInfo(menuId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
@@ -15,4 +15,17 @@ public class MenuWriter {
 	public Menu postMenu(Long storeId, Long userId, Long menuCategoryId, MenuInfo menuInfo) {
 		return menuRepository.postMenu(storeId, userId, menuCategoryId, menuInfo);
 	}
+
+	public MenuInfo patchMenu(MenuInfo patchMenuInfo) {
+		return menuRepository.patchMenu(patchMenuInfo);
+	}
+
+	public MenuInfo patchMenuOrder(Long storeId, Long menuCategoryId, Long menuId, int order) {
+		return menuRepository.patchMenuOrder(storeId, menuCategoryId, menuId, order);
+	}
+
+	public void deleteMenu(Long storeId, Long menuCategoryId, Long menuId) {
+		menuRepository.deleteMenu(storeId, menuCategoryId, menuId);
+	}
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuCategoryRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuCategoryRepository.java
@@ -1,11 +1,19 @@
 package domain.pos.menu.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import domain.pos.menu.entity.MenuCategory;
 
 public interface MenuCategoryRepository {
-	MenuCategory postMenuCategory(String categoryName);
+	MenuCategory postMenuCategory(Long storeId, String categoryName);
 
 	Optional<MenuCategory> getMenuCategory(Long categoryId);
+
+	List<MenuCategory> getMenuCategoryList(Long storeId);
+
+	MenuCategory patchMenuCategory(Long categoryId, String categoryName);
+
+	void deleteMenuCategory(Long categoryId);
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
@@ -9,9 +9,20 @@ import domain.pos.menu.entity.Menu;
 import domain.pos.menu.entity.MenuInfo;
 
 public interface MenuRepository {
+	// TODO : 존재하는 order 값이라면 order 이상 메뉴들의 order+1
 	Menu postMenu(Long storeId, Long userId, Long menuCategoryId, MenuInfo menuInfo);
 
 	Optional<MenuInfo> getMenuInfo(Long menuId);
 
 	Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId);
+
+	// TODO : patch 할 때, order은 수정하지 않도록 구현
+	MenuInfo patchMenu(MenuInfo patchMenuInfo);
+
+	// TODO : Infra 계층 구현 시 동일 가게, 동일 카테고리 내에 지정 order 이상인 메뉴들은 ++order 하도록 구현
+	MenuInfo patchMenuOrder(Long storeId, Long menuCategoryId, Long menuId, int order);
+
+	// TODO : Infra 계층 구현 시 동일 가게, 동일 카테고리 내에 삭제 메뉴 order 초과인 메뉴들은 --order 하도록 구현
+	void deleteMenu(Long storeId, Long menuCategoryId, Long menuId);
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
@@ -1,9 +1,17 @@
 package domain.pos.menu.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
 import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.implement.MenuCategoryReader;
+import domain.pos.menu.implement.MenuCategoryValidator;
 import domain.pos.menu.implement.MenuCategoryWriter;
+import domain.pos.store.implement.StoreReader;
 import domain.pos.store.implement.StoreValidator;
 import lombok.RequiredArgsConstructor;
 
@@ -11,10 +19,30 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MenuCategoryService {
 	private final StoreValidator storeValidator;
+	private final MenuCategoryValidator menuCategoryValidator;
+	private final StoreReader storeReader;
 	private final MenuCategoryWriter menuCategoryWriter;
+	private final MenuCategoryReader menuCategoryReader;
 
 	public MenuCategory postMenuCategory(Long storeId, Long userId, String categoryName) {
 		storeValidator.validateStoreOwner(storeId, userId);
-		return menuCategoryWriter.postMenuCategory(categoryName);
+		return menuCategoryWriter.postMenuCategory(storeId, categoryName);
+	}
+
+	public List<MenuCategory> getMenuCategoryList(Long storeId) {
+		storeReader.readSingleStore(storeId).orElseThrow(() -> new ServiceException(ErrorCode.NOT_FOUND_STORE));
+		return menuCategoryReader.getMenuCategoryList(storeId);
+	}
+
+	public MenuCategory patchMenuCategory(Long storeId, Long userId, Long categoryId, String categoryName) {
+		storeValidator.validateStoreOwner(storeId, userId);
+		menuCategoryValidator.validateMenuCategory(categoryId);
+		return menuCategoryWriter.patchMenuCategory(categoryId, categoryName);
+	}
+
+	public void deleteMenuCategory(Long storeId, Long userId, Long categoryId) {
+		storeValidator.validateStoreOwner(storeId, userId);
+		menuCategoryValidator.validateMenuCategory(categoryId);
+		menuCategoryWriter.deleteMenuCategory(categoryId);
 	}
 }

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuCategoryServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuCategoryServiceTest.java
@@ -1,8 +1,12 @@
 package domain.pos.menu;
 
 import static fixtures.menu.MenuCategoryFixture.*;
+import static fixtures.store.StoreFixture.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,15 +20,24 @@ import com.exception.ServiceException;
 
 import base.ServiceTest;
 import domain.pos.menu.entity.MenuCategory;
+import domain.pos.menu.implement.MenuCategoryReader;
+import domain.pos.menu.implement.MenuCategoryValidator;
 import domain.pos.menu.implement.MenuCategoryWriter;
 import domain.pos.menu.service.MenuCategoryService;
+import domain.pos.store.implement.StoreReader;
 import domain.pos.store.implement.StoreValidator;
 
 public class MenuCategoryServiceTest extends ServiceTest {
 	@Mock
 	private StoreValidator storeValidator;
 	@Mock
+	private MenuCategoryValidator menuCategoryValidator;
+	@Mock
+	private StoreReader storeReader;
+	@Mock
 	private MenuCategoryWriter menuCategoryWriter;
+	@Mock
+	private MenuCategoryReader menuCategoryReader;
 	@InjectMocks
 	private MenuCategoryService menuCategoryService;
 
@@ -40,9 +53,9 @@ public class MenuCategoryServiceTest extends ServiceTest {
 		@Test
 		void 메뉴_카테고리_생성_성공() {
 			// given
-			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId, categoryName);
+			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId, categoryName, storeId);
 
-			BDDMockito.given(menuCategoryWriter.postMenuCategory(categoryName))
+			BDDMockito.given(menuCategoryWriter.postMenuCategory(storeId, categoryName))
 				.willReturn(menuCategory);
 
 			// when
@@ -70,7 +83,7 @@ public class MenuCategoryServiceTest extends ServiceTest {
 				verify(storeValidator)
 					.validateStoreOwner(storeId, userId);
 				verify(menuCategoryWriter, never())
-					.postMenuCategory(categoryName);
+					.postMenuCategory(storeId, categoryName);
 			});
 		}
 
@@ -89,7 +102,231 @@ public class MenuCategoryServiceTest extends ServiceTest {
 				verify(storeValidator)
 					.validateStoreOwner(storeId, userId);
 				verify(menuCategoryWriter, never())
-					.postMenuCategory(categoryName);
+					.postMenuCategory(storeId, categoryName);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 카테고리 리스트 조회")
+	class getMenuCategoryList {
+		private final Long menuCategoryId = MENU_CATEGORY_ID;
+		private final String categoryName = CATEGORY_NAME;
+		private final Long storeId = STORE_ID;
+
+		@Test
+		void 메뉴_카테고리_리스트_조회_성공() {
+			// given
+			MenuCategory menuCategory = GENERAL_MENU_CATEGORY();
+
+			BDDMockito.given(storeReader.readSingleStore(storeId))
+				.willReturn(Optional.of(CUSTOM_STORE(storeId, null, null)));
+			BDDMockito.given(menuCategoryReader.getMenuCategoryList(storeId))
+				.willReturn(List.of(menuCategory));
+
+			// when
+			List<MenuCategory> menuCategoryList = menuCategoryService.getMenuCategoryList(storeId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(menuCategoryList.get(0).getMenuCategoryId()).isEqualTo(menuCategoryId);
+				softly.assertThat(menuCategoryList.get(0).getMenuCategoryName()).isEqualTo(categoryName);
+				softly.assertThat(menuCategoryList.get(0).getStoreId()).isEqualTo(storeId);
+			});
+		}
+
+		@Test
+		void 가게_조회_실패() {
+			// given
+			BDDMockito.given(storeReader.readSingleStore(storeId))
+				.willReturn(Optional.empty());
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.getMenuCategoryList(storeId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeReader)
+					.readSingleStore(storeId);
+				verify(menuCategoryReader, never())
+					.getMenuCategoryList(storeId);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 카테고리 수정")
+	class patchMenuCategory {
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final Long categoryId = 3L;
+		private final String categoryName = "categoryName";
+
+		@Test
+		void 메뉴_카테고리_수정_성공() {
+			// given
+			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(categoryId, categoryName, storeId);
+
+			BDDMockito.given(menuCategoryWriter.patchMenuCategory(categoryId, categoryName))
+				.willReturn(menuCategory);
+
+			// when
+			MenuCategory serviceMenuCategory = menuCategoryService.patchMenuCategory(storeId, userId, categoryId,
+				categoryName);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(serviceMenuCategory.getMenuCategoryId()).isEqualTo(categoryId);
+				softly.assertThat(serviceMenuCategory.getMenuCategoryName()).isEqualTo(categoryName);
+				softly.assertThat(serviceMenuCategory.getStoreId()).isEqualTo(storeId);
+			});
+		}
+
+		@Test
+		void 가게_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.patchMenuCategory(storeId, userId, categoryId,
+						categoryName))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.patchMenuCategory(categoryId, categoryName);
+			});
+		}
+
+		@Test
+		void 점주_인증_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.patchMenuCategory(storeId, userId, categoryId,
+						categoryName))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.patchMenuCategory(categoryId, categoryName);
+			});
+		}
+
+		@Test
+		void 메뉴_카테고리_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.MENU_CATEGORY_NOT_FOUND))
+				.when(menuCategoryValidator)
+				.validateMenuCategory(categoryId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.patchMenuCategory(storeId, userId, categoryId,
+						categoryName))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_CATEGORY_NOT_FOUND);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator)
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.patchMenuCategory(categoryId, categoryName);
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 카테고리 삭제")
+	class deleteMenuCategory {
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final Long categoryId = 3L;
+
+		@Test
+		void 메뉴_카테고리_삭제_성공() {
+			// when
+			menuCategoryService.deleteMenuCategory(storeId, userId, categoryId);
+
+			// then
+			verify(menuCategoryWriter)
+				.deleteMenuCategory(categoryId);
+
+		}
+
+		@Test
+		void 가게_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(storeId, userId, categoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.deleteMenuCategory(categoryId);
+			});
+		}
+
+		@Test
+		void 점주_인증_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator)
+				.validateStoreOwner(storeId, userId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(storeId, userId, categoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator, never())
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.deleteMenuCategory(categoryId);
+			});
+		}
+
+		@Test
+		void 메뉴_카테고리_조회_실패() {
+			// given
+			doThrow(new ServiceException(ErrorCode.MENU_CATEGORY_NOT_FOUND))
+				.when(menuCategoryValidator)
+				.validateMenuCategory(categoryId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(() -> menuCategoryService.deleteMenuCategory(storeId, userId, categoryId))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_CATEGORY_NOT_FOUND);
+				verify(storeValidator)
+					.validateStoreOwner(storeId, userId);
+				verify(menuCategoryValidator)
+					.validateMenuCategory(categoryId);
+				verify(menuCategoryWriter, never())
+					.deleteMenuCategory(categoryId);
 			});
 		}
 	}

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
@@ -71,7 +71,7 @@ public class MenuServiceTest extends ServiceTest {
 		void 메뉴_생성_성공() {
 			// given
 			StoreInfo storeInfo = GENERAL_STORE_INFO();
-			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId);
+			MenuCategory menuCategory = CUSTOM_MENU_CATEGORY(menuCategoryId, storeId);
 			Menu menu = CUSTOM_MENU(REQUEST_TO_ENTITY(menuId, requestMenuInfo), storeInfo, menuCategory);
 
 			BDDMockito.given(menuWriter.postMenu(storeId, userId, menuCategoryId, requestMenuInfo))

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
@@ -33,6 +33,7 @@ import domain.pos.menu.entity.MenuCategory;
 import domain.pos.menu.entity.MenuInfo;
 import domain.pos.menu.implement.MenuCategoryValidator;
 import domain.pos.menu.implement.MenuReader;
+import domain.pos.menu.implement.MenuValidator;
 import domain.pos.menu.implement.MenuWriter;
 import domain.pos.menu.service.MenuService;
 import domain.pos.store.entity.Store;
@@ -43,6 +44,8 @@ import domain.pos.store.implement.StoreValidator;
 public class MenuServiceTest extends ServiceTest {
 	@Mock
 	private StoreValidator storeValidator;
+	@Mock
+	private MenuValidator menuValidator;
 	@Mock
 	private MenuCategoryValidator menuCategoryValidator;
 	@Mock
@@ -161,7 +164,7 @@ public class MenuServiceTest extends ServiceTest {
 
 	@Nested
 	@DisplayName("메뉴 리스트 조회")
-	class getMenuSlice {
+	class getMenu {
 		private final int size = 10;
 		private final boolean hasNext = false;
 		private final Pageable pageable = Pageable.ofSize(size);
@@ -272,6 +275,64 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader, never())
 					.getMenuSlice(any(Pageable.class), any(MenuInfo.class), any(Long.class));
 			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 수정")
+	class patchMenu {
+		private final String patchMenuName = "patchMenuName";
+		private final int patchPrice = 20000;
+		private final String patchDescription = "patchDescription";
+		private final String patchImageUrl = "patchImageUrl";
+		private final boolean patchIsSoldOut = false;
+
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final Long menuId = 3L;
+		private final MenuInfo patchMenuInfo = CUSTOM_MENU_INFO(menuId, patchMenuName, patchPrice, patchDescription,
+			patchImageUrl,
+			patchIsSoldOut);
+
+		private final Long menuCategoryId = 4L;
+		private final int order = 1;
+
+		@Test
+		void 메뉴_수정_성공() {
+			// given
+			BDDMockito.given(menuWriter.patchMenu(patchMenuInfo))
+				.willReturn(patchMenuInfo);
+
+			// when
+			MenuInfo servicePatchMenuInfo = menuService.patchMenu(storeId, userId, patchMenuInfo);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(servicePatchMenuInfo.getMenuName()).isEqualTo(patchMenuInfo.getMenuName());
+				softly.assertThat(servicePatchMenuInfo.getPrice()).isEqualTo(patchMenuInfo.getPrice());
+				softly.assertThat(servicePatchMenuInfo.getDescription()).isEqualTo(patchMenuInfo.getDescription());
+				softly.assertThat(servicePatchMenuInfo.getImageUrl()).isEqualTo(patchMenuInfo.getImageUrl());
+				softly.assertThat(servicePatchMenuInfo.isSoldOut()).isEqualTo(patchMenuInfo.isSoldOut());
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("메뉴 삭제")
+	class deleteMenu {
+		private final Long storeId = 1L;
+		private final Long userId = 2L;
+		private final Long menuCategoryId = 3L;
+		private final Long menuId = 4L;
+
+		@Test
+		void 메뉴_삭제_성공() {
+			// when
+			menuService.deleteMenu(storeId, userId, menuCategoryId, menuId);
+
+			// then
+			verify(menuWriter)
+				.deleteMenu(storeId, menuCategoryId, menuId);
 		}
 	}
 }

--- a/domain/domain-pos/src/test/java/fixtures/menu/MenuCategoryFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/menu/MenuCategoryFixture.java
@@ -3,20 +3,31 @@ package fixtures.menu;
 import domain.pos.menu.entity.MenuCategory;
 
 public class MenuCategoryFixture {
-	private static final Long MENU_CATEGORY_ID = 1L;
-	private static final String CATEGORY_NAME = "categoryName";
+	public static final Long MENU_CATEGORY_ID = 1L;
+	public static final String CATEGORY_NAME = "categoryName";
+	public static final Long STORE_ID = 1L;
 
-	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId) {
+	public static MenuCategory GENERAL_MENU_CATEGORY() {
 		return MenuCategory.builder()
-			.menuCategoryId(menuCategoryId)
+			.menuCategoryId(MENU_CATEGORY_ID)
 			.menuCategoryName(CATEGORY_NAME)
+			.storeId(STORE_ID)
 			.build();
 	}
 
-	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId, String categoryName) {
+	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId, Long storeId) {
+		return MenuCategory.builder()
+			.menuCategoryId(menuCategoryId)
+			.menuCategoryName(CATEGORY_NAME)
+			.storeId(storeId)
+			.build();
+	}
+
+	public static MenuCategory CUSTOM_MENU_CATEGORY(Long menuCategoryId, String categoryName, Long storeId) {
 		return MenuCategory.builder()
 			.menuCategoryId(menuCategoryId)
 			.menuCategoryName(categoryName)
+			.storeId(storeId)
 			.build();
 	}
 }

--- a/domain/domain-pos/src/test/java/fixtures/menu/MenuInfoFixture.java
+++ b/domain/domain-pos/src/test/java/fixtures/menu/MenuInfoFixture.java
@@ -8,6 +8,7 @@ public class MenuInfoFixture {
 	private static final int GENERAL_PRICE = 10000;
 	private static final String GENERAL_DESCRIPTION = "menu description";
 	private static final String GENERAL_IMAGEURL = "imageURL";
+	private static final boolean GENERAL_IS_SOLD_OUT = false;
 
 	public static MenuInfo REQUEST_MENU_INFO() {
 		return MenuInfo.builder()
@@ -15,6 +16,7 @@ public class MenuInfoFixture {
 			.price(GENERAL_PRICE)
 			.description(GENERAL_DESCRIPTION)
 			.imageUrl(GENERAL_IMAGEURL)
+			.isSoldOut(GENERAL_IS_SOLD_OUT)
 			.build();
 	}
 
@@ -25,6 +27,7 @@ public class MenuInfoFixture {
 			.price(GENERAL_PRICE)
 			.description(GENERAL_DESCRIPTION)
 			.imageUrl(GENERAL_IMAGEURL)
+			.isSoldOut(GENERAL_IS_SOLD_OUT)
 			.build();
 	}
 
@@ -35,6 +38,19 @@ public class MenuInfoFixture {
 			.price(GENERAL_PRICE)
 			.description(GENERAL_DESCRIPTION)
 			.imageUrl(GENERAL_IMAGEURL)
+			.isSoldOut(GENERAL_IS_SOLD_OUT)
+			.build();
+	}
+
+	public static MenuInfo CUSTOM_MENU_INFO(Long menuId, String menuName, int price, String description,
+		String imageUrl, boolean isSoldOut) {
+		return MenuInfo.builder()
+			.menuId(menuId)
+			.menuName(menuName)
+			.price(price)
+			.description(description)
+			.imageUrl(imageUrl)
+			.isSoldOut(isSoldOut)
 			.build();
 	}
 
@@ -45,6 +61,7 @@ public class MenuInfoFixture {
 			.price(requestMenuInfo.getPrice())
 			.description(requestMenuInfo.getDescription())
 			.imageUrl(requestMenuInfo.getImageUrl())
+			.isSoldOut(requestMenuInfo.isSoldOut())
 			.build();
 	}
 }


### PR DESCRIPTION
1️⃣ 단일 메뉴 상세조회
---
![image](https://github.com/user-attachments/assets/f6e9dac6-0b53-4c11-bd3e-3705afbac7ab)

2️⃣ 메뉴 세부내용 수정
---
![image](https://github.com/user-attachments/assets/c004bf46-f9b1-4df4-bae4-1c127c8c0d76)

3️⃣ 메뉴 순서 수정
---
![image](https://github.com/user-attachments/assets/c7b03552-f2a1-49a0-8876-94664d5a62dc)

4️⃣ 메뉴 삭제
---
![image](https://github.com/user-attachments/assets/4af58299-4424-4089-b905-38d00674461c)

✅ 강조사항
---
- 메뉴 순서 수정 및 메뉴 삭제 시 대상 메뉴의 순서 이상인 메뉴들의 순서를 조정할 필요가 있습니다.
- 수정, 삭제 메서드와 분리된 도메인 메서드로 구현하지 않고, infra 단에서 같은 트랜잭션을 가지게 동일한 메서드로 묶은 후 구현할 예정입니다.