### PR TITLE
pos 시스템 infra 모듈 jpa 설정 및 query dsl 설정 작업 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ out/
 ### Conventional Commit ###
 /node_modules
 
-
+**/data

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,8 @@ editorconfig {
             'application/**/data',
             '**/*.dblwr',
             'settings.gradle',
-            '**/docker-infra'
+            '**/docker-infra',
+            '**/data'
     ]
 }
 

--- a/infra/rdb/pos/build.gradle
+++ b/infra/rdb/pos/build.gradle
@@ -1,8 +1,47 @@
 bootJar { enabled = false }
 jar { enabled = true }
 
+
 dependencies {
+    // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // MySQL / H2
     runtimeOnly 'com.mysql:mysql-connector-j'
-    compileOnly(project(':domain:domain-pos'))
+    runtimeOnly 'com.h2database:h2'
+
+    // domain 모듈
+    compileOnly project(':domain:domain-pos')
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Test
+    testImplementation project(':domain:domain-pos')
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
+
+
+// ### QueryDSL 관련 설정 시작 ###
+// Querydsl Q Class 생성 위치
+def querydslDir = 'build/generated/querydsl'
+
+// java source set 에 Querydsl Q Class 위치 추가
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+// 생성된 Q Class가 컴파일될 디렉토리 설정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// gradle clean 시, Q Class가 위치한 디렉토리 삭제
+clean {
+    delete file(querydslDir)
+}
+
+

--- a/infra/rdb/pos/build.gradle
+++ b/infra/rdb/pos/build.gradle
@@ -1,0 +1,8 @@
+bootJar { enabled = false }
+jar { enabled = true }
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    compileOnly(project(':domain:domain-pos'))
+}

--- a/infra/rdb/pos/docker/docker-compose.yml
+++ b/infra/rdb/pos/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  mysql:
+    image: mysql:latest
+    container_name: pos_module_mysql
+    ports:
+      - 3314:3306
+    environment:
+      MYSQL_DATABASE: local-pos-mysql
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_ROOT_PASSWORD: 123456789
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+    volumes:
+      - ./data/:/var/lib/mysql

--- a/infra/rdb/pos/readme.md
+++ b/infra/rdb/pos/readme.md
@@ -1,0 +1,36 @@
+## infra - rdb - pos 모듈
+
+### 소개
+
+pos 시스템에서 안정성 높고 영속화를 보장하는 RDBMS에 접근하는 구현체 모듈
+
+domain-pos 모듈을 의존하며 domain-pos 의 Repository Interface를 구현하는 모듈이다.
+
+mysql - jpa - query dsl - spring data jpa 를 사용하여 구현한다.
+
+### 로컬에서 사용하는 법
+
+```bash
+docker compose -f infra/rdb/pos/docker/docker-compose.yml up -d
+```
+
+- 로컬 환경에서 docker compose 로 구성된 mysql 서버를 실행한다.
+
+### 테스트 코드 작성하는 법
+
+```java
+
+@DataJpaTest
+@Import({JpaConfig.class, JpaComponentConfig.class, QueryDSLConfig.class})
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {JpaConfig.class, JpaComponentConfig.class, QueryDSLConfig.class})
+public abstract class RepositoryTest {
+}
+
+```
+
+위 클래스를 의존하여 테스트 코드 작성하면 됨
+
+spring bean 인 Repository를 주입 받는다면 위 추상 클래스에 선언하도록 하는 것을 권장
+-> 이유는 빈 컨테이너 초기화를 단축하여 Test 시간 최소화를 위해
+

--- a/infra/rdb/pos/src/main/java/com/pos/config/InfraAutoConfig.java
+++ b/infra/rdb/pos/src/main/java/com/pos/config/InfraAutoConfig.java
@@ -1,0 +1,9 @@
+package com.pos.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+
+@AutoConfiguration
+@ComponentScan(basePackages = "com.pos")
+public class InfraAutoConfig {
+}

--- a/infra/rdb/pos/src/main/java/com/pos/config/JpaComponentConfig.java
+++ b/infra/rdb/pos/src/main/java/com/pos/config/JpaComponentConfig.java
@@ -1,0 +1,16 @@
+package com.pos.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@ComponentScan(basePackages = "com.pos")
+@EnableTransactionManagement
+@EntityScan(basePackages = "com.pos")
+@EnableJpaRepositories(basePackages = "com.pos")
+public class JpaComponentConfig {
+}
+

--- a/infra/rdb/pos/src/main/java/com/pos/config/JpaConfig.java
+++ b/infra/rdb/pos/src/main/java/com/pos/config/JpaConfig.java
@@ -1,0 +1,34 @@
+package com.pos.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class JpaConfig {
+	private final DataSource dataSource;
+
+	@Bean
+	@Primary
+	public LocalContainerEntityManagerFactoryBean entityManagerFactory(EntityManagerFactoryBuilder builder) {
+		return builder
+			.dataSource(dataSource)
+			.packages("com.pos") // 엔티티 클래스 패키지
+			.build();
+	}
+
+	@Bean
+	public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
+		return new JpaTransactionManager(emf);
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/config/QueryDSLConfig.java
+++ b/infra/rdb/pos/src/main/java/com/pos/config/QueryDSLConfig.java
@@ -1,0 +1,21 @@
+package com.pos.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDSLConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/infra/rdb/pos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/infra/rdb/pos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.pos.config.InfraAutoConfig

--- a/infra/rdb/pos/src/main/resources/application.yml
+++ b/infra/rdb/pos/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3314/local-pos-mysql
+    username: root
+    password: 123456789
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        highlight_sql: false
+        hbm2ddl.auto: create-drop
+        default_batch_fetch_size: 100
+    open-in-view: false
+    show-sql: true

--- a/infra/rdb/pos/src/test/java/com/pos/config/RepositoryTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/config/RepositoryTest.java
@@ -1,0 +1,13 @@
+package com.pos.config;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@DataJpaTest
+@Import({JpaConfig.class, JpaComponentConfig.class, QueryDSLConfig.class})
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {JpaConfig.class, JpaComponentConfig.class, QueryDSLConfig.class})
+public abstract class RepositoryTest {
+}

--- a/infra/rdb/pos/src/test/resources/application-test.yml
+++ b/infra/rdb/pos/src/test/resources/application-test.yml
@@ -1,0 +1,15 @@
+datasource:
+  driver-class-name: org.h2.Driver
+  url: jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;
+  username: sa
+  password:
+
+jpa:
+  database: h2
+  generate-ddl: false
+  open-in-view: false
+  hibernate:
+    ddl-auto: create-drop
+  properties:
+    hibernate:
+      dialect: org.hibernate.dialect.MySQL8Dialect

--- a/infra/rdb/pos/src/test/resources/application-test.yml
+++ b/infra/rdb/pos/src/test/resources/application-test.yml
@@ -1,15 +1,16 @@
-datasource:
-  driver-class-name: org.h2.Driver
-  url: jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;
-  username: sa
-  password:
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;
+    username: sa
+    password:
 
-jpa:
-  database: h2
-  generate-ddl: false
-  open-in-view: false
-  hibernate:
-    ddl-auto: create-drop
-  properties:
+  jpa:
+    database: h2
+    generate-ddl: true
+    open-in-view: false
     hibernate:
-      dialect: org.hibernate.dialect.MySQL8Dialect
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,6 @@ include(":common:base")
 // domain
 include(":domain:domain-pos")
 
+// infra
+include(":infra:rdb:pos")
+


### PR DESCRIPTION

## 🍀 작업사항

### 1️⃣ infra 모듈 구성

![image](https://github.com/user-attachments/assets/20332ca6-d39b-490b-9d3a-99c619e5ac84)

- pos 시스템의 데이터를 저장할 rdb  infra 인 mysql ,Jpa 의존 코드들이 있는 모듈을 구성했습니다.
- 기존 pos domain 비즈니스 모듈의 interface를 구현하도록 했습니다.

### 2️⃣ mysql datasource 및 jpa config 작업 

- 설정에 포함된 datasource 대로 config component를 bean 화 시키도록 작업했습니다 (JpaConfig.class)
- jpa 관련 컴포넌트 jpa entity , spring data repository 를 로드할 수 있도록 config 작업했습니다 (JpaComponent.class)
- 추후 presentation 모듈인 pos application 이 해당 모듈을 의존하면 위 config class 들이 자동 구성되도록 작업했습니다(InfraAutoConfig.class)

### 3️⃣ query dsl 구성 

- query dsl queryFactory 및 QEntity 클래스 구성 작업을 완료 했습니다.

### 4️⃣ test 환경에서 mysql 단위 테스트 설정

- RepositoryTest 추상 클래스를 의존하면 인메모리(h2) 로 Infra 계층 단위 테스트가 가능합니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced application configuration now includes a containerized MySQL service for local development with persistent storage.
  - Introduced a new infrastructure module that improves database integration, transaction management, and query functionality.
  - Added refined environment profiles to support local development and production consistency.
  - New README documentation for the infrastructure module detailing its purpose, usage, and testing guidelines.

- **Tests**
  - Updated testing configurations and repository testing setups have been implemented for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->