### PR TITLE
점주 실시간 주문 내역  갱신 서버 초기 개발 및 이벤트 모델링

### DIFF
--- a/application/event/build.gradle
+++ b/application/event/build.gradle
@@ -1,0 +1,18 @@
+bootJar {
+    enabled = true
+}
+jar {
+    enabled = false
+}
+
+dependencies {
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+}

--- a/application/event/src/main/java/com/event/EventApplication.java
+++ b/application/event/src/main/java/com/event/EventApplication.java
@@ -1,0 +1,11 @@
+package com.event;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EventApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(EventApplication.class, args);
+	}
+}

--- a/application/event/src/main/java/com/event/channel/OwnerStoreChannel.java
+++ b/application/event/src/main/java/com/event/channel/OwnerStoreChannel.java
@@ -1,0 +1,75 @@
+package com.event.channel;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.event.message.StoreOrderEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class OwnerStoreChannel {
+	private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+	private static final long TIMEOUT = 60 * 1000;
+	private static final long RECONNECTION_TIMEOUT = 1000L;
+	private static final String EVENT_NAME = "OwnerStoreEvent-";
+
+	public SseEmitter subscribe(Long storeId) {
+		SseEmitter emitter = setUpSseEmitter(storeId);
+		emitterMap.put(storeId, emitter);
+		try {
+			SseEmitter.SseEventBuilder event = SseEmitter.event()
+				.name(EVENT_NAME + String.valueOf(storeId))
+				.id(String.valueOf("id-1"))
+				.data("SSE connected")
+				.reconnectTime(RECONNECTION_TIMEOUT);
+			emitter.send(event);
+		} catch (IOException e) {
+			log.error("failure send media position data, id={}, {}", storeId, e.getMessage());
+		}
+		return emitter;
+	}
+
+	public void unicast(Long storeId, StoreOrderEvent storeOrderEvent) {
+		SseEmitter emitter = emitterMap.get(storeId);
+		try {
+			emitter.send(SseEmitter.event()
+				.name("broadcast event")
+				.id("broadcast event 1")
+				.reconnectTime(RECONNECTION_TIMEOUT)
+				.data(storeOrderEvent, MediaType.APPLICATION_JSON));
+			log.info("sended notification, id={}, payload={}", storeId, storeOrderEvent);
+		} catch (IOException e) {
+			log.error("fail to send emitter id={}, {}", storeId, e.getMessage());
+		}
+	}
+
+	private SseEmitter setUpSseEmitter(Long storeId) {
+		SseEmitter emitter = createEmitter();
+		emitter.onTimeout(() -> {
+			log.info("server sent event timed out : id={}", storeId);
+			emitter.complete();
+		});
+		emitter.onError(e -> {
+			log.info("server sent event error occurred : id={}, message={}", storeId, e.getMessage());
+			emitter.complete();
+		});
+		emitter.onCompletion(() -> {
+			if (emitterMap.remove(storeId) != null) {
+				log.info("server sent event removed in emitter cache: id={}", storeId);
+			}
+			log.info("disconnected by completed server sent event: id={}", storeId);
+		});
+		return emitter;
+	}
+
+	private SseEmitter createEmitter() {
+		return new SseEmitter(TIMEOUT);
+	}
+}

--- a/application/event/src/main/java/com/event/controller/SsePosController.java
+++ b/application/event/src/main/java/com/event/controller/SsePosController.java
@@ -1,0 +1,44 @@
+package com.event.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.event.message.StoreOrderEvent;
+import com.event.service.SsePosService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SsePosController {
+	private final SsePosService ssePosService;
+
+	// @HasRole(userRole = UserRole.ROLE_ANONYMOUS)
+	// @AssignUserPassport TODO : 이거는 나중에 추가해야함 모듈화 되면 추가해야함
+	@GetMapping(path = "/api/v1/owner/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public ResponseEntity<SseEmitter> subscribe(
+		// TODO : 이거는 나중에 UserPassport 로 바꿔야함
+		@RequestParam Long ownerId,
+		@RequestParam Long storeId) {
+		log.info("SSE Subscribe 요청 ownerId: {} storeId: {}", ownerId, storeId);
+		SseEmitter emitter = ssePosService.subscribeByOwner(ownerId, storeId);
+		return ResponseEntity.ok(emitter);
+	}
+
+	// TODO: 임시 테스트 용
+	@PostMapping(path = "/api/v1/owner/unicast")
+	public ResponseEntity<Void> unicast(
+		@RequestParam Long storeId,
+		@RequestBody StoreOrderEvent storeOrderEvent) {
+		ssePosService.unicast(storeId, storeOrderEvent);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/application/event/src/main/java/com/event/implement/OwnerStoreValidator.java
+++ b/application/event/src/main/java/com/event/implement/OwnerStoreValidator.java
@@ -1,0 +1,14 @@
+package com.event.implement;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class OwnerStoreValidator {
+	public void validate(Long ownerId, Long storeId) {
+		// TODO: 회의 후 구현해야함
+		return;
+	}
+}

--- a/application/event/src/main/java/com/event/message/StoreOrderEvent.java
+++ b/application/event/src/main/java/com/event/message/StoreOrderEvent.java
@@ -1,0 +1,26 @@
+package com.event.message;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+//TODO : 추후 내역 수정
+public record StoreOrderEvent(
+	Long tableId,
+	Integer tableNumber,
+	Order order
+) {
+	public record Order(
+		Long orderId,
+		LocalDateTime createdAt,
+		List<OrderMenu> orderMenu
+	) {
+		public record OrderMenu(
+			Long menuId,
+			String menuName,
+			Integer menuPrice,
+			Integer menuCount,
+			String menuStatus // TODO : 추후 enum으로 변경
+		) {
+		}
+	}
+}

--- a/application/event/src/main/java/com/event/service/SsePosService.java
+++ b/application/event/src/main/java/com/event/service/SsePosService.java
@@ -1,0 +1,30 @@
+package com.event.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.event.channel.OwnerStoreChannel;
+import com.event.implement.OwnerStoreValidator;
+import com.event.message.StoreOrderEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SsePosService {
+	private final OwnerStoreChannel ownerStoreChannel;
+	private final OwnerStoreValidator ownerStoreValidator;
+
+	public SseEmitter subscribeByOwner(Long ownerId, Long storeId) {
+		ownerStoreValidator.validate(ownerId, storeId);
+		SseEmitter emitter = ownerStoreChannel.subscribe(storeId);
+		return emitter;
+	}
+
+	public void unicast(Long storeId, StoreOrderEvent storeOrderEvent) {
+		ownerStoreChannel.unicast(storeId, storeOrderEvent);
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include(':application:config')
 include(':application:discovery')
 include(':application:gateway')
 include(':application:auth')
+include((':application:event'))
 
 // common
 include(":common:discovery-client")


### PR DESCRIPTION

## 🍀 작업 사항

### 1️⃣  점주 주문 갱신 이벤트 모델링

```java
public record StoreOrderEvent(
	Long tableId,
	Integer tableNumber,
	Order order
) {
	public record Order(
		Long orderId,
		LocalDateTime createdAt,
		List<OrderMenu> orderMenu
	) {
		public record OrderMenu(
			Long menuId,
			String menuName,
			Integer menuPrice,
			Integer menuCount,
			String menuStatus // TODO : 추후 enum으로 변경
		) {
		}
	}
}
``` 

- 점주는 위 데이터에 해당하는 정보를 실시간으로 SSE 서버로부터 받습니다.


### 2️⃣ SSE subscribe 개발

- 클라이언트와 SSE 서버간에 데이터 통신시 다음과 같은 신뢰성 없는 통신이 생길 수 있습니다. 
1. 데이터 유실
2. 데이터 중복
3. 데이터 순서 꼬임

- 데이터 중복은 이벤트 데이터 안에 orderId라는 Order 일련번호가 있기 때문에 중복 처리는 클라이언트에서 처리 가능하다고 판단
- 데이터 순서 꼬임은 유실만 되지 않는다면 문제 없다고 판단

마지막 데이터 유실은 다음 상황에서 발생할 수 있습니다

![image](https://github.com/user-attachments/assets/981ae7dd-a497-473e-b6b6-21896774b329)

따라서 다음과 같이 클라이언트가 재연결시 fetch 하는 rest api 를 제공하여 이를 해소할 수 있습니다

![image](https://github.com/user-attachments/assets/3fe34d76-504c-4540-9358-31a225ba4098)

하지만 fetch 를 한다고 해도 다음과 같은 상황에서 데이터 유실을 탐지할 수 없습니다.

![image](https://github.com/user-attachments/assets/0a607d4a-e256-486c-aaea-ef5bf0421232)

결론은 SSE 커넥션 타임아웃을 짧게 가져가서 데이터가 유실되더라도 최대한 빠르게 이를 알아챌 수 있도록 했습니다.


## ❓ 의논 사항

- 추가로 점주가 테이블의 활성화 내역(몇번 테이블 활성화되어 있는지 같은)을 실시간으로 새로고침 하지 않고 받을지 고민해야 함 ( 필요하다면 StoreOrderEvent 와 별개의 이벤트를 모델링할 예정)
- 사용자가 동시 주문시 장바구니에 담을 때 실시간으로 내역을 받을 필요 있다면 이벤트를 추가할 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new module supporting real-time Server-Sent Events (SSE) for store owners, enabling subscription to live order updates via dedicated endpoints.
  - Added REST API endpoints for subscribing to SSE streams and sending order events to specific stores.
  - Integrated API documentation support for easier exploration and testing of endpoints.
- **Chores**
  - Updated project configuration to include the new event module in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->