### PR TITLE
StoreOrder Event Producer 개발 및 카프카 모듈 리팩터링

### DIFF
--- a/application/yabam/yabam-event/src/main/java/com/event/EventApplication.java
+++ b/application/yabam/yabam-event/src/main/java/com/event/EventApplication.java
@@ -2,8 +2,14 @@ package com.event;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = {
+	"com.pos.consumer.store.order",
+	"com.pos.consumer",
+	"com.event"
+})
 public class EventApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(EventApplication.class, args);

--- a/domain/domain-event/store-event/src/main/java/com/pos/producer/StoreOrderProducer.java
+++ b/domain/domain-event/store-event/src/main/java/com/pos/producer/StoreOrderProducer.java
@@ -1,0 +1,7 @@
+package com.pos.producer;
+
+import com.pos.event.StoreOrderEvent;
+
+public interface StoreOrderProducer {
+	void produceStoreOrder(String key, StoreOrderEvent storeOrderEvent);
+}

--- a/infra/mq/kafka-pos/build.gradle
+++ b/infra/mq/kafka-pos/build.gradle
@@ -7,7 +7,7 @@ jar {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
     // domain-event
     compileOnly project(':domain:domain-event:store-event')

--- a/infra/mq/kafka-pos/build.gradle
+++ b/infra/mq/kafka-pos/build.gradle
@@ -11,4 +11,12 @@ dependencies {
 
     // domain-event
     compileOnly project(':domain:domain-event:store-event')
+
+    // test
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation project(':domain:domain-event:store-event')
+
+
 }

--- a/infra/mq/kafka-pos/src/main/java/com/pos/KafkaPosApplication.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/KafkaPosApplication.java
@@ -1,0 +1,10 @@
+package com.pos;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KafkaPosApplication {
+	public static void main(String[] args) {
+		org.springframework.boot.SpringApplication.run(KafkaPosApplication.class, args);
+	}
+}

--- a/infra/mq/kafka-pos/src/main/java/com/pos/config/KafkaAutoConfig.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/config/KafkaAutoConfig.java
@@ -1,9 +1,0 @@
-package com.pos.config;
-
-import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-
-@AutoConfiguration
-@ComponentScan(basePackages = "com.pos")
-public class KafkaAutoConfig {
-}

--- a/infra/mq/kafka-pos/src/main/java/com/pos/consumer/store/order/KafkaStoreOrderEventListener.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/consumer/store/order/KafkaStoreOrderEventListener.java
@@ -1,6 +1,5 @@
 package com.pos.consumer.store.order;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -12,25 +11,31 @@ import com.pos.consumer.StoreOrderHandler;
 import com.pos.event.StoreOrderEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "event.listener", havingValue = "kafka", matchIfMissing = true)
 public class KafkaStoreOrderEventListener {
 	private final StoreOrderHandler storeOrderHandler;
 	private final ObjectMapper mapper;
 
-	@KafkaListener(topics = "store-orders", groupId = "store-order-consumer")
+	@KafkaListener(topics = "${kafka.store.order.topic}", groupId = "${kafka.store.order.group-id}")
 	public void listen(@Header(KafkaHeaders.RECEIVED_KEY) String key, String json) {
+		log.info("KafkaStoreOrderEventListener listen() - key: {}, json: {}", key, json);
 		try {
 			StoreOrderEvent storeOrderEvent = mapper.readValue(json, StoreOrderEvent.class);
 			onOrderEvent(key, storeOrderEvent);
 		} catch (JsonProcessingException e) {
+			log.error("KafkaStoreOrderEventListener listen() - JSON 변환 실패, key: {}, json: {}, error: {}",
+				key,
+				json,
+				e.getMessage());
 			throw new RuntimeException(e);
 		}
 	}
 
-	public void onOrderEvent(String key, StoreOrderEvent storeOrderEvent) {
+	private void onOrderEvent(String key, StoreOrderEvent storeOrderEvent) {
 		storeOrderHandler.handleStoreOrder(key, storeOrderEvent);
 	}
 }

--- a/infra/mq/kafka-pos/src/main/java/com/pos/consumer/store/order/config/KafkaConsumerConfig.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/consumer/store/order/config/KafkaConsumerConfig.java
@@ -1,4 +1,4 @@
-package com.pos.config;
+package com.pos.consumer.store.order.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/infra/mq/kafka-pos/src/main/java/com/pos/global/properties/KafkaStoreOrderProperties.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/global/properties/KafkaStoreOrderProperties.java
@@ -1,0 +1,36 @@
+package com.pos.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kafka.store.order")
+public class KafkaStoreOrderProperties {
+	private String topic;
+	private String groupId;
+	private String bootstrapServers;
+
+	public String getTopic() {
+		return topic;
+	}
+
+	public void setTopic(String topic) {
+		this.topic = topic;
+	}
+
+	public String getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	public String getBootstrapServers() {
+		return bootstrapServers;
+	}
+
+	public void setBootstrapServers(String bootstrapServers) {
+		this.bootstrapServers = bootstrapServers;
+	}
+}

--- a/infra/mq/kafka-pos/src/main/java/com/pos/producer/store/order/KafkaStoreOrderProducer.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/producer/store/order/KafkaStoreOrderProducer.java
@@ -1,0 +1,44 @@
+package com.pos.producer.store.order;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pos.event.StoreOrderEvent;
+import com.pos.global.properties.KafkaStoreOrderProperties;
+import com.pos.producer.StoreOrderProducer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaStoreOrderProducer implements StoreOrderProducer {
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final KafkaStoreOrderProperties properties;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void produceStoreOrder(String key, StoreOrderEvent storeOrderEvent) {
+		String message;
+		try {
+			message = objectMapper.writeValueAsString(storeOrderEvent);
+		} catch (JsonProcessingException e) {
+			log.error("객체 문자열 JSON으로 변환 실패 에러 메시지 : {} ", e.getMessage());
+			throw new RuntimeException(e);
+		}
+		kafkaTemplate.send(properties.getTopic(), key, message)
+			.whenComplete((record, ex) -> {
+				if (ex != null) { //TODO : 카프카 전송 실패 관련 처리 추가 해야함
+					log.error("카프카 메시지 전송 실패 토픽 : {}, key : {}, 에러 메시지 : {}  ",
+						properties.getTopic(),
+						key,
+						ex.getMessage());
+				} else {
+					log.info("카프카 메시지 전송 성공, topic: {}, key: {}", properties.getTopic(), key);
+				}
+			});
+	}
+}

--- a/infra/mq/kafka-pos/src/main/java/com/pos/producer/store/order/config/KafkaProcuerConfig.java
+++ b/infra/mq/kafka-pos/src/main/java/com/pos/producer/store/order/config/KafkaProcuerConfig.java
@@ -1,0 +1,37 @@
+package com.pos.producer.store.order.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import com.pos.global.properties.KafkaStoreOrderProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@Import(KafkaStoreOrderProperties.class)
+public class KafkaProcuerConfig {
+	private final KafkaStoreOrderProperties kafkaStoreOrderProperties;
+
+	@Bean
+	public KafkaTemplate<String, String> kafkaTemplate() {
+		Map<String, Object> producerProps = new HashMap<>();
+		producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaStoreOrderProperties.getBootstrapServers());
+		producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
+		producerProps.put(ProducerConfig.RETRIES_CONFIG, 1000);
+		producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
+		ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProps);
+		return new KafkaTemplate<>(producerFactory);
+	}
+}

--- a/infra/mq/kafka-pos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/infra/mq/kafka-pos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,0 @@
-com.pos.config.KafkaAutoConfig

--- a/infra/mq/kafka-pos/src/test/java/com/pos/consumer/store/order/KafkaStoreOrderEventListenerTest.java
+++ b/infra/mq/kafka-pos/src/test/java/com/pos/consumer/store/order/KafkaStoreOrderEventListenerTest.java
@@ -1,0 +1,66 @@
+package com.pos.consumer.store.order;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.pos.consumer.StoreOrderHandler;
+import com.pos.consumer.store.order.config.KafkaConsumerConfig;
+import com.pos.event.StoreOrderEvent;
+import com.pos.producer.store.order.KafkaStoreOrderProducer;
+import com.pos.producer.store.order.config.KafkaProcuerConfig;
+
+@SpringBootTest
+@Import(value = {KafkaProcuerConfig.class,
+	KafkaConsumerConfig.class,
+	KafkaStoreOrderEventListener.class
+})
+@DirtiesContext
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, topics = {"${kafka.store.order.topic}"},
+	brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
+class KafkaStoreOrderEventListenerTest {
+
+	@MockitoBean
+	private StoreOrderHandler storeOrderHandler;
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	private KafkaStoreOrderProducer kafkaStoreOrderProducer;
+
+	@Test
+	void kafkaListenerTest() throws Exception {
+		// given
+		StoreOrderEvent storeOrderEvent = new StoreOrderEvent(
+			10L,
+			5,
+			new StoreOrderEvent.Order(
+				1001L,
+				LocalDateTime.now(),
+				List.of(new StoreOrderEvent.Order.OrderMenu(1L, "Americano", 3000, 2, "ORDERED"))
+			)
+		);
+		TimeUnit.SECONDS.sleep(1);
+		// when
+		kafkaStoreOrderProducer.produceStoreOrder("1", storeOrderEvent);
+		kafkaTemplate.flush();
+
+		// then
+		verify(storeOrderHandler, timeout(1000))
+			.handleStoreOrder(anyString(), any(StoreOrderEvent.class));
+	}
+}

--- a/infra/mq/kafka-pos/src/test/resources/application-test.yml
+++ b/infra/mq/kafka-pos/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+kafka:
+  store:
+    order:
+      topic: store-order
+      group-id: store-order-consumer
+      bootstrap-servers: localhost:9092


### PR DESCRIPTION

## 🍀 작업사항

### 1️⃣ kafka 모듈 의존 리팩터링 

이전
- 기존 kafka 모듈 AutoConfiguration 으로 자동 구성을 채택했습니다
이후
- 의존하는 계층에서 패키지 주소를 명시하여 필요한 구성만 bean 구성하도록 했습니다.

### 2️⃣ kafka producer 구현

kafka producer 에서 구현할 수 있는 데이터 중복, 데이터 순서 불일치 , 데이터 손실 문제에서
해당 도메인 파이프라인이 위 3개의 문제를 고려할 필요 없다고 판단했습니다 (sse 서버에서 fetch sync 작업을 하기 때문에)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Kafka integration for store order events, including configuration for topics, group IDs, and bootstrap servers.
  - Added the ability to produce and consume store order events via Kafka.
  - Externalized Kafka configuration properties for easier management.

- **Improvements**
  - Enhanced logging for Kafka event processing, including detailed success and error logs.
  - Kafka listener configuration is now controlled via external properties for better flexibility.

- **Bug Fixes**
  - Adjusted dependency scopes to ensure test dependencies do not affect production runtime.

- **Tests**
  - Added comprehensive tests for Kafka store order event listener functionality using embedded Kafka and mock handlers.
  - Introduced test-specific configuration for Kafka properties.

- **Chores**
  - Refined package structure and removed unused auto-configuration to streamline application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->