### PR TITLE
store 정보에 테이블 당 비용 정보 추가

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/request/StoreWriteRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/request/StoreWriteRequest.java
@@ -4,6 +4,7 @@ import java.awt.geom.Point2D;
 
 import domain.pos.store.entity.StoreInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -25,7 +26,15 @@ public record StoreWriteRequest(
 	@NotBlank(message = "가게 대표 이미지는 필수입니다.")
 	String headImageUrl,
 	@Schema(description = "가게 소속 대학교", example = "서울대학교")
-	String university
+	String university,
+	@Schema(description = "가게 테이블 시간", example = "30")
+	@NotNull(message = "가게 테이블 시간은 필수입니다.")
+	@Min(value = 1, message = "가게 테이블 시간은 1분 이상이어야 합니다.")
+	Integer tableTime,
+	@Schema(description = "가게 테이블 비용", example = "10000")
+	@NotNull(message = "가게 테이블 비용은 필수입니다.")
+	@Min(value = 0, message = "가게 테이블 비용은 0원 이상이어야 합니다.")
+	Integer tableCost
 ) {
 	public StoreInfo toStoreInfo() {
 		return StoreInfo.of(
@@ -33,7 +42,9 @@ public record StoreWriteRequest(
 			new Point2D.Double(latitude, longitude),
 			description,
 			headImageUrl,
-			university
+			university,
+			tableTime,
+			tableCost
 		);
 	}
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
@@ -26,7 +26,11 @@ public record StoreInfoResponse(
 	@Schema(description = "가게 대표 이미지 URL", example = "https://example.com/image.jpg")
 	String headImageUrl,
 	@Schema(description = "가게 소속 대학교", example = "서울대학교")
-	String university
+	String university,
+	@Schema(description = "가게 테이블 시간", example = "30")
+	Integer tableTime,
+	@Schema(description = "가게 테이블 비용", example = "10000")
+	Integer tableCost
 ) {
 	public static StoreInfoResponse of(Store store) {
 		return StoreInfoResponse.builder()
@@ -40,6 +44,8 @@ public record StoreInfoResponse(
 			.description(store.getStoreInfo().getDescription())
 			.headImageUrl(store.getStoreInfo().getHeadImageUrl())
 			.university(store.getStoreInfo().getUniversity())
+			.tableTime(store.getStoreInfo().getTableTime())
+			.tableCost(store.getStoreInfo().getTableCost())
 			.build();
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/StoreInfo.java
@@ -11,23 +11,29 @@ public class StoreInfo {
 	private final String description;
 	private final String headImageUrl;
 	private final String university;
+	private final Integer tableTime;
+	private final Integer tableCost;
 
 	private StoreInfo(String storeName, Point2D.Double location, String description, String headImageUrl,
-		String university) {
+		String university, Integer tableTime, Integer tableCost) {
 		this.storeName = storeName;
 		this.location = location;
 		this.description = description;
 		this.headImageUrl = headImageUrl;
 		this.university = university;
+		this.tableTime = tableTime;
+		this.tableCost = tableCost;
 	}
 
 	public static StoreInfo of(String storeName, Point2D.Double location, String desciption, String headImageUrl,
-		String university) {
+		String university, Integer tableTime, Integer tableCost) {
 		return new StoreInfo(
 			storeName,
 			location,
 			desciption,
 			headImageUrl,
-			university);
+			university,
+			tableTime,
+			tableCost);
 	}
 }

--- a/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreInfoFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreInfoFixture.java
@@ -20,6 +20,12 @@ public class StoreInfoFixture {
 	// 가게 대학교
 	private static final String STORE_UNIVERSITY = "금오공과대학교";
 	private static final String STORE_UNIVERSITY_2 = "서울대학교";
+	// 가게 테이블 시간
+	private static final Integer STORE_TABLE_TIME = 30;
+	private static final Integer STORE_TABLE_TIME_2 = 60;
+	// 가게 테이블 비용
+	private static final Integer STORE_TABLE_COST = 10000;
+	private static final Integer STORE_TABLE_COST_2 = 20000;
 
 	public static StoreInfo GENERAL_STORE_INFO() {
 		return StoreInfo.of(
@@ -27,7 +33,9 @@ public class StoreInfoFixture {
 			STORE_LOCATION,
 			STORE_DESCRIPTION,
 			STORE_IMAGE_URL,
-			STORE_UNIVERSITY
+			STORE_UNIVERSITY,
+			STORE_TABLE_TIME,
+			STORE_TABLE_COST
 		);
 	}
 
@@ -37,7 +45,9 @@ public class StoreInfoFixture {
 			STORE_LOCATION_2,
 			STORE_DESCRIPTION_2,
 			STORE_IMAGE_URL_2,
-			STORE_UNIVERSITY_2
+			STORE_UNIVERSITY_2,
+			STORE_TABLE_TIME_2,
+			STORE_TABLE_COST_2
 		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
@@ -101,6 +101,7 @@ public class StoreEntity extends BaseEntity {
 		this.name = requestChangeStoreInfo.getStoreName();
 		this.headImageUrl = requestChangeStoreInfo.getHeadImageUrl();
 		this.description = requestChangeStoreInfo.getDescription();
+		this.university = requestChangeStoreInfo.getUniversity();
 		this.location = StorePoint.of(
 			requestChangeStoreInfo.getLocation().x,
 			requestChangeStoreInfo.getLocation().y

--- a/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
@@ -5,6 +5,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 import com.pos.global.base.entity.BaseEntity;
 import com.pos.store.vo.StorePoint;
+import com.pos.store.vo.TableCostPerTime;
 
 import domain.pos.store.entity.StoreInfo;
 import jakarta.persistence.Column;
@@ -50,8 +51,11 @@ public class StoreEntity extends BaseEntity {
 	@Column(name = "university", nullable = false)
 	private String university;
 
+	@Embedded
+	private TableCostPerTime tableCostPerTime;
+
 	private StoreEntity(Long ownerId, boolean isOpen, String name, StorePoint location, String description,
-		String headImageUrl, String university) {
+		String headImageUrl, String university, TableCostPerTime tableCostPerTime) {
 		this.ownerId = ownerId;
 		this.isOpen = isOpen;
 		this.name = name;
@@ -59,6 +63,7 @@ public class StoreEntity extends BaseEntity {
 		this.description = description;
 		this.headImageUrl = headImageUrl;
 		this.university = university;
+		this.tableCostPerTime = tableCostPerTime;
 	}
 
 	private StoreEntity(Long storeId) {
@@ -73,7 +78,9 @@ public class StoreEntity extends BaseEntity {
 		Double longitude,
 		String description,
 		String headImageUrl,
-		String university) {
+		String university,
+		Integer tableTime,
+		Integer tableCost) {
 		return new StoreEntity(
 			ownerId,
 			isOpen,
@@ -81,7 +88,8 @@ public class StoreEntity extends BaseEntity {
 			StorePoint.of(latitude, longitude),
 			description,
 			headImageUrl,
-			university
+			university,
+			TableCostPerTime.of(tableTime, tableCost)
 		);
 	}
 
@@ -96,6 +104,10 @@ public class StoreEntity extends BaseEntity {
 		this.location = StorePoint.of(
 			requestChangeStoreInfo.getLocation().x,
 			requestChangeStoreInfo.getLocation().y
+		);
+		this.tableCostPerTime = TableCostPerTime.of(
+			requestChangeStoreInfo.getTableTime(),
+			requestChangeStoreInfo.getTableCost()
 		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -21,7 +21,9 @@ public class StoreMapper {
 			storeInfo.getLocation().getY(),
 			storeInfo.getDescription(),
 			storeInfo.getHeadImageUrl(),
-			storeInfo.getUniversity()
+			storeInfo.getUniversity(),
+			storeInfo.getTableTime(),
+			storeInfo.getTableCost()
 		);
 	}
 
@@ -35,7 +37,9 @@ public class StoreMapper {
 			new Point2D.Double(storeEntity.getLocation().getLatitude(), storeEntity.getLocation().getLongitude()),
 			storeEntity.getDescription(),
 			storeEntity.getHeadImageUrl(),
-			storeEntity.getUniversity()
+			storeEntity.getUniversity(),
+			storeEntity.getTableCostPerTime().getTableTime(),
+			storeEntity.getTableCostPerTime().getTableCost()
 		);
 	}
 

--- a/infra/rdb/pos/src/main/java/com/pos/store/vo/TableCostPerTime.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/vo/TableCostPerTime.java
@@ -1,0 +1,39 @@
+package com.pos.store.vo;
+
+import com.exception.VoException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TableCostPerTime {
+	@Column(name = "table_time", nullable = false)
+	private Integer tableTime;
+
+	@Column(name = "table_cost", nullable = false)
+	private Integer tableCost;
+
+	private TableCostPerTime(Integer tableTime, Integer tableCost) {
+		validate(tableTime, tableCost);
+		this.tableTime = tableTime;
+		this.tableCost = tableCost;
+	}
+
+	public static TableCostPerTime of(Integer tableTime, Integer tableCost) {
+		return new TableCostPerTime(tableTime, tableCost);
+	}
+
+	private void validate(Integer tableTime, Integer tableCost) {
+		if (tableTime <= 0) {
+			throw new VoException("테이블 시간은 1보다 커야 합니다.");
+		}
+		if (tableCost < 0) {
+			throw new VoException("테이블 비용은 음수일 수 없습니다.");
+		}
+	}
+}

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -43,6 +43,8 @@ class StoreRepositoryImplTest extends RepositoryTest {
 			softly.assertThat(findStoreEntity.getLocation().getLatitude()).isEqualTo(changedStoreInfo.getLocation().x);
 			softly.assertThat(findStoreEntity.getLocation().getLongitude()).isEqualTo(changedStoreInfo.getLocation().y);
 			softly.assertThat(findStoreEntity.getDescription()).isEqualTo(changedStoreInfo.getDescription());
+			softly.assertThat(findStoreEntity.getHeadImageUrl()).isEqualTo(changedStoreInfo.getHeadImageUrl());
+			softly.assertThat(findStoreEntity.getUniversity()).isEqualTo(changedStoreInfo.getUniversity());
 			softly.assertThat(findStoreEntity.getTableCostPerTime().getTableCost())
 				.isEqualTo(changedStoreInfo.getTableCost());
 			softly.assertThat(findStoreEntity.getTableCostPerTime().getTableTime())

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -43,6 +43,10 @@ class StoreRepositoryImplTest extends RepositoryTest {
 			softly.assertThat(findStoreEntity.getLocation().getLatitude()).isEqualTo(changedStoreInfo.getLocation().x);
 			softly.assertThat(findStoreEntity.getLocation().getLongitude()).isEqualTo(changedStoreInfo.getLocation().y);
 			softly.assertThat(findStoreEntity.getDescription()).isEqualTo(changedStoreInfo.getDescription());
+			softly.assertThat(findStoreEntity.getTableCostPerTime().getTableCost())
+				.isEqualTo(changedStoreInfo.getTableCost());
+			softly.assertThat(findStoreEntity.getTableCostPerTime().getTableTime())
+				.isEqualTo(changedStoreInfo.getTableTime());
 		});
 	}
 


### PR DESCRIPTION
## 🍀 작업사항

### 1️⃣ Store 정보에 테이블 당 비용 정보 추가

- [x] domain 모듈 엔티티 Store에 StoreInfo 에 테이블 이용 시간당 비용 정보 추가
  - [x] tableTime : 요금 청구 단위 시간
  - [x] tableCost  : 청구 비용
  - [x] test 코드 성공
 
- [x] infra 모듈 엔티티 StoreEntity에 TableCostPerTime 로 테이블 이용 시간당 비용 정보 추가
  - [x] TableCostPerTime.getTableTime : 요금 청구 단위 시간
  - [x] TableCostPerTime.getTableCost  : 청구 비용
  - [x] test 코드 성공

- [x] application dto 에 테이블  이용 시간당 비용 정보 추가
  - [x] request dto 에 추가
  - [x] response dto 에 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying table time and table cost for stores. These details can now be provided when creating or updating store information and are visible in store responses.

- **Bug Fixes**
  - Improved validation to ensure table time and table cost are present and meet minimum value requirements.

- **Tests**
  - Enhanced tests to verify correct handling and storage of table time and table cost fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->