### PR TITLE
cart 기능 도메인 구현

### DIFF
--- a/domain/domain-pos/src/main/java/domain/pos/cart/entity/Cart.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/entity/Cart.java
@@ -1,0 +1,20 @@
+package domain.pos.cart.entity;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class Cart {
+	private Long receiptId;
+	private List<CartMenu> cartMenus;
+
+	private Cart(Long receiptId, List<CartMenu> cartMenus) {
+		this.receiptId = receiptId;
+		this.cartMenus = cartMenus;
+	}
+
+	public static Cart of(Long receiptId, List<CartMenu> cartMenus) {
+		return new Cart(receiptId, cartMenus);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/cart/entity/CartMenu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/entity/CartMenu.java
@@ -1,0 +1,19 @@
+package domain.pos.cart.entity;
+
+import domain.pos.menu.entity.MenuInfo;
+import lombok.Getter;
+
+@Getter
+public class CartMenu {
+	private Integer quantity;
+	private MenuInfo menuInfo;
+
+	private CartMenu(Integer quantity, MenuInfo menuInfo) {
+		this.quantity = quantity;
+		this.menuInfo = menuInfo;
+	}
+
+	public static CartMenu of(Integer quantity, MenuInfo menuInfo) {
+		return new CartMenu(quantity, menuInfo);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/cart/implement/CartWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/implement/CartWriter.java
@@ -1,0 +1,30 @@
+package domain.pos.cart.implement;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import domain.pos.cart.entity.Cart;
+import domain.pos.cart.repository.CartRepository;
+import domain.pos.menu.entity.MenuInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CartWriter {
+	private final CartRepository cartRepository;
+
+	public Cart upsertCart(final Long receiptId, final MenuInfo menuInfo, final Integer quantity) {
+		return cartRepository.postCart(receiptId, menuInfo, quantity);
+	}
+
+	public void deleteCartMenu(Long receiptId, Long menuId) {
+		cartRepository.deleteCartMenu(receiptId, menuId);
+	}
+
+	public Optional<Cart> getCart(Long receiptId) {
+		return cartRepository.getCart(receiptId);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/cart/repository/CartRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/repository/CartRepository.java
@@ -1,0 +1,17 @@
+package domain.pos.cart.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import domain.pos.cart.entity.Cart;
+import domain.pos.menu.entity.MenuInfo;
+
+@Repository
+public interface CartRepository {
+	Cart postCart(Long receiptId, MenuInfo menuInfo, Integer quantity);
+
+	void deleteCartMenu(Long receiptId, Long menuId);
+
+	Optional<Cart> getCart(Long receiptId);
+}

--- a/domain/domain-pos/src/main/java/domain/pos/cart/service/CartService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/service/CartService.java
@@ -1,0 +1,34 @@
+package domain.pos.cart.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import domain.pos.cart.entity.Cart;
+import domain.pos.cart.implement.CartWriter;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.implement.MenuReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CartService {
+	private final MenuReader menuReader;
+	private final CartWriter cartWriter;
+
+	public Cart upsertCart(final Long receiptId, final Long menuId, final Integer quantity) {
+		final MenuInfo menuInfo = menuReader.getMenuInfoById(menuId);
+
+		return cartWriter.upsertCart(receiptId, menuInfo, quantity);
+	}
+
+	public void deleteCart(final Long receiptId, final Long menuId) {
+		cartWriter.deleteCartMenu(receiptId, menuId);
+	}
+
+	public Optional<Cart> getCart(final Long receiptId) {
+		return cartWriter.getCart(receiptId);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
 import domain.pos.menu.entity.Menu;
 import domain.pos.menu.entity.MenuInfo;
 import domain.pos.menu.repository.MenuRepository;
@@ -38,5 +41,10 @@ public class MenuReader {
 
 	public boolean existsMenuOrder(Long menuCategoryId, int menuOrder) {
 		return menuRepository.existsMenuOrder(menuCategoryId, menuOrder);
+	}
+
+	public MenuInfo getMenuInfoById(Long menuId) {
+		return menuRepository.getMenuInfoById(menuId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
@@ -28,4 +28,5 @@ public interface MenuRepository {
 
 	void deleteMenu(Menu menu);
 
+	Optional<MenuInfo> getMenuInfoById(Long menuId);
 }

--- a/domain/domain-pos/src/test/java/domain/pos/cart/service/CartServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/cart/service/CartServiceTest.java
@@ -1,0 +1,120 @@
+package domain.pos.cart.service;
+
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import base.ServiceTest;
+import domain.pos.cart.entity.Cart;
+import domain.pos.cart.implement.CartWriter;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.menu.implement.MenuReader;
+import fixtures.cart.CartFixture;
+
+class CartServiceTest extends ServiceTest {
+
+	@Mock
+	private MenuReader menuReader;
+
+	@Mock
+	private CartWriter cartWriter;
+
+	@InjectMocks
+	private CartService cartService;
+
+	@Nested
+	class upsertCartTest {
+		@Test
+		void 성공() {
+			// given
+			final Cart responCart = CartFixture.GENERAL_CART_SINGLE();
+			final Long receiptId = responCart.getReceiptId();
+			final Long menuId = responCart.getCartMenus().get(0).getMenuInfo().getId();
+			final Integer quantity = responCart.getCartMenus().get(0).getQuantity();
+
+			doReturn(responCart.getCartMenus().get(0).getMenuInfo())
+				.when(menuReader).getMenuInfoById(anyLong());
+			doReturn(responCart)
+				.when(cartWriter).upsertCart(anyLong(), any(MenuInfo.class), anyInt());
+			// when
+			final Cart cart = cartService.upsertCart(receiptId, menuId, quantity);
+
+			// then
+			assertSoftly(softly -> {
+				verify(menuReader).getMenuInfoById(anyLong());
+				verify(cartWriter).upsertCart(anyLong(), any(MenuInfo.class), anyInt());
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("장바구니 삭제")
+	class DeleteCartTest {
+
+		@Test
+		void 성공() {
+			// given
+			Long receiptId = 1L;
+			Long menuId = 10L;
+
+			// when
+			cartService.deleteCart(receiptId, menuId);
+
+			// then
+			assertSoftly(softly -> {
+				verify(cartWriter).deleteCartMenu(receiptId, menuId);
+				// 반환값 없으므로 추가 assert 필요 없음
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("장바구니 조회")
+	class GetCartTest {
+
+		@Test
+		void 성공_장바구니존재() {
+			// given
+			Cart expected = CartFixture.GENERAL_CART_SINGLE();
+			Long receiptId = expected.getReceiptId();
+
+			doReturn(Optional.of(expected))
+				.when(cartWriter).getCart(receiptId);
+
+			// when
+			Optional<Cart> result = cartService.getCart(receiptId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isPresent()
+					.contains(expected);
+				verify(cartWriter).getCart(receiptId);
+			});
+		}
+
+		@Test
+		void 빈옵션_장바구니없음() {
+			// given
+			Long receiptId = 404L;
+			doReturn(Optional.empty())
+				.when(cartWriter).getCart(receiptId);
+
+			// when
+			Optional<Cart> result = cartService.getCart(receiptId);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(result).isEmpty();
+				verify(cartWriter).getCart(receiptId);
+			});
+		}
+	}
+
+}

--- a/domain/domain-pos/src/testFixtures/java/fixtures/cart/CartFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/cart/CartFixture.java
@@ -1,0 +1,28 @@
+package fixtures.cart;
+
+import java.util.List;
+
+import domain.pos.cart.entity.Cart;
+import domain.pos.cart.entity.CartMenu;
+import fixtures.menu.MenuInfoFixture;
+
+public class CartFixture {
+	public static final Long RECEIPT_ID = 1L;
+
+	private static final List<CartMenu> SINGLE_CART_MENUS = List.of(
+		CartMenu.of(1, MenuInfoFixture.GENERAL_MENU_INFO())
+	);
+
+	private static final List<CartMenu> TWO_CART_MENUS = List.of(
+		CartMenu.of(1, MenuInfoFixture.GENERAL_MENU_INFO()),
+		CartMenu.of(4, MenuInfoFixture.DIFF_MENU_INFO())
+	);
+
+	public static Cart GENERAL_CART_SINGLE() {
+		return Cart.of(RECEIPT_ID, SINGLE_CART_MENUS);
+	}
+
+	public static Cart GENERAL_CART_TWO() {
+		return Cart.of(RECEIPT_ID, TWO_CART_MENUS);
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
@@ -111,4 +111,10 @@ public class MenuRepositoryImpl implements MenuRepository {
 		menuJpaRepository.decreaseOrderWhereGT(menu.getMenuCategory().getMenuCategoryInfo().getId(),
 			periodOrder);
 	}
+
+	@Override
+	public Optional<MenuInfo> getMenuInfoById(Long menuId) {
+		return menuJpaRepository.findById(menuId)
+			.map(MenuMapper::toMenuInfo);
+	}
 }


### PR DESCRIPTION
## 🍀 작없사항


### 1️⃣  cart  기능  crud 구현

<img src="https://github.com/user-attachments/assets/b5d6b010-d94b-4997-82cc-c849bb87e2b6" width="50%" alt="이미지 설명">

- 위 기획을 보면 장바구니에 메뉴를 담을 수 있고 만약 이상태에서 동일한 메뉴를 추가로 담는다면 메뉴의 개수를 증가합니다
- 담겨져 있는 메뉴의 개수를 줄일 수 없도록 기획되어 있습니다.
- 위 디자인 기획에는 안나타져 있지만 + 버튼을 있을거 같습니다. 하지만 - 버튼은 존재하지 않고 메뉴 삭제만 있을거 같습니다( 배민 참고함)

### ❓ discussion

해당 도메인 로직에 receiptId 나 sale 이 open 되어 있는지 판단하지 않습니다. 이유는 receiptId 를 유효성 검증을 한다고 해서 qr을 통한 receiptId 인지 검증할 방법이 없기 때문이라고 생각했습니다. </br>
 그리고 sale 이 open 되어 있지 않다고 해도 해당 내역은 장바구니이고 결제 상태가 될 때 검증을 한번 더 하기 때문에 무의미한 검증이라고 생각했습니다. </br>
제 관점은 장바구니는 조금의 오류가 발생해도 크리티컬하지 않다고 판단했습니다.
참조되는 데이터의 안정성보다는 성능에 초점을 맞췄습니다. 장바구니는 많은 요청 그리고 많은 polling 요청을 날릴 것이기 때문에 빠르고 가벼워야 한다고 판단했습니다.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced shopping cart functionality, allowing users to add, update, and remove menu items from their cart.
  - Users can retrieve their current cart contents by receipt ID.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive tests to ensure correct cart behavior and reliability.

- **Chores**
  - Added reusable test fixtures for cart-related testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->