### PR TITLE
Order, OrderMenu Infra 로직 구현 및 일부 도메인 서비스 로직 리팩토링

### DIFF
--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
+	// Common
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_0001", "잘못된 입력 값입니다."),
 	// Owner
 	NOT_VALID_OWNER(HttpStatus.BAD_REQUEST, "OWNER_0001", "해당 사용자는 가게 점주가 아닙니다"),
 
@@ -33,6 +35,7 @@ public enum ErrorCode {
 	EXIST_MENU_ORDER(HttpStatus.CONFLICT, "MENU_0002", "이미 존재하는 메뉴 순서입니다."),
 	STORE_IS_OPEN_MENU_WRITE(HttpStatus.CONFLICT, "MENU_0003", "운영중인 가게는 메뉴를 추가 및 수정할 수 없습니다."),
 	MENU_ORDER_INVALID(HttpStatus.BAD_REQUEST, "MENU_0004", "메뉴 순서가 유효하지 않습니다."),
+	MENU_SOLD_OUT(HttpStatus.BAD_REQUEST, "MENU_0005", "메뉴가 품절되었습니다."),
 
 	// MenuCategory
 	MENU_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_CATEGORY_0001", "존재하지 않는 메뉴 카테고리입니다."),
@@ -55,6 +58,7 @@ public enum ErrorCode {
 	// Sale
 	NOT_FOUND_SALE(HttpStatus.NOT_FOUND, "SALE_0001", "존재하지 않는 세일입니다."),
 	CLOSE_SALE(HttpStatus.CONFLICT, "SALE_0002", "영업이 종료되었습니다."),
+	SALE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "SALE_0003", "대상 영업에 접근 가능한 요청이 아닙니다."),
 
 	// Receipt
 	RECEIPT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECEIPT_0001", "존재하지 않는 영수증입니다."),
@@ -66,14 +70,24 @@ public enum ErrorCode {
 	ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_0002", "대상 주문에 접근 가능한 요청이 아닙니다."),
 	INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "ORDER_0003", "주문 상태 전환이 불가능합니다."),
 	ALREADY_RECEIVED_ORDER(HttpStatus.BAD_REQUEST, "ORDER_0004", "이미 접수된 주문입니다."),
-	ALREADY_CANCELLED_ORDER(HttpStatus.BAD_REQUEST, "ORDER_0005", "이미 취소된 주문입니다."),
+	ALREADY_CANCELED_ORDER(HttpStatus.BAD_REQUEST, "ORDER_0005", "이미 취소된 주문입니다."),
 	ALREADY_COMPLETED_ORDER(HttpStatus.BAD_REQUEST, "ORDER_0006", "이미 완료된 주문입니다."),
+	TRANSFER_INVALID_STATUS(HttpStatus.BAD_REQUEST, "ORDER_0007", "주문 상태 전환이 불가능합니다."),
+	ORDER_STATUS_NOT_RECEIVED(HttpStatus.BAD_REQUEST, "ORDER_0008", "주문 상태가 접수되지 않았습니다."),
 
 	// VoException
 	NOT_VALID_VO(HttpStatus.BAD_REQUEST, "VO_0001", "Vo 객체가 유효하지 않습니다."),
 
 	// OrderMenu
-	ORDER_MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_MENU_0001", "존재하지 않는 주문 메뉴입니다.");
+	ORDER_MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_MENU_0001", "존재하지 않는 주문 메뉴입니다."),
+	ORDER_MENU_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_MENU_0002", "대상 주문 메뉴에 접근 가능한 요청이 아닙니다."),
+	ALREADY_COOKING_ORDER_MENU(HttpStatus.BAD_REQUEST, "ORDER_MENU_0003", "이미 조리중인 메뉴입니다."),
+	ALREADY_CANCELED_ORDER_MENU(HttpStatus.BAD_REQUEST, "ORDER_MENU_0004", "이미 취소된 메뉴입니다."),
+	ALREADY_COMPLETED_ORDER_MENU(HttpStatus.BAD_REQUEST, "ORDER_MENU_0005", "이미 완료된 메뉴입니다."),
+
+	// Cart
+	CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CART_0001", "존재하지 않는 장바구니입니다."),
+	CART_EMPTY(HttpStatus.BAD_REQUEST, "CART_0002", "장바구니가 비어있습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/domain/domain-pos/src/main/java/domain/pos/cart/implement/CartWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/implement/CartWriter.java
@@ -26,4 +26,8 @@ public class CartWriter {
 	public Optional<Cart> getCart(Long receiptId) {
 		return cartRepository.getCart(receiptId);
 	}
+
+	public void deleteCartAndCartMenuByReceiptId(Long receiptId) {
+		cartRepository.deleteCartAndCartMenuByReceiptId(receiptId);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/Menu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/Menu.java
@@ -18,4 +18,8 @@ public class Menu {
 	public static Menu of(MenuInfo menuInfo, Store store, MenuCategory menuCategory) {
 		return new Menu(menuInfo, store, menuCategory);
 	}
+
+	public void changeFullInfoMenuInfo(MenuInfo menuInfo) {
+		this.menuInfo = menuInfo;
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategoryInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/entity/MenuCategoryInfo.java
@@ -14,7 +14,7 @@ public class MenuCategoryInfo {
 		this.order = order;
 	}
 
-	public static MenuCategoryInfo of(Long id, String name, int order) {
+	public static MenuCategoryInfo of(Long id, String name, Integer order) {
 		return new MenuCategoryInfo(id, name, order);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
@@ -2,6 +2,7 @@ package domain.pos.menu.implement;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
@@ -39,7 +40,7 @@ public class MenuReader {
 		return menuRepository.existsMenuOrder(menuCategoryId, menuOrder);
 	}
 
-	public Long countByIdIn(Long storeId, List<Long> menuIds) {
+	public Long countByIdIn(Long storeId, Set<Long> menuIds) {
 		return menuRepository.countByIdIn(storeId, menuIds);
 	}
 

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuReader.java
@@ -3,7 +3,6 @@ package domain.pos.menu.implement;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
@@ -28,16 +27,20 @@ public class MenuReader {
 			.findFirst();
 	}
 
-	public Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId) {
-		return menuRepository.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+	public Slice<MenuInfo> getMenuSlice(int pageSize, MenuInfo lastMenuInfo, Long menuCategoryId) {
+		return menuRepository.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId);
 	}
 
 	public boolean existsMenu(Long storeId, Long menuId) {
-		return menuRepository.getMenuInfo(storeId, menuId).isPresent();
+		return menuRepository.existsMenu(storeId, menuId);
 	}
 
 	public boolean existsMenuOrder(Long menuCategoryId, int menuOrder) {
 		return menuRepository.existsMenuOrder(menuCategoryId, menuOrder);
+	}
+
+	public Long countByIdIn(Long storeId, List<Long> menuIds) {
+		return menuRepository.countByIdIn(storeId, menuIds);
 	}
 
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/implement/MenuWriter.java
@@ -18,8 +18,8 @@ public class MenuWriter {
 		return menuRepository.postMenu(store, menuCategory, menuInfo);
 	}
 
-	public MenuInfo patchMenu(MenuInfo patchMenuInfo) {
-		return menuRepository.patchMenu(patchMenuInfo);
+	public MenuInfo patchMenuInfo(MenuInfo patchMenuInfo) {
+		return menuRepository.patchMenuInfo(patchMenuInfo);
 	}
 
 	public MenuInfo patchMenuOrder(Menu menu, Integer patchOrder) {

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
@@ -2,6 +2,7 @@ package domain.pos.menu.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
@@ -31,7 +32,7 @@ public interface MenuRepository {
 
 	void deleteMenu(Menu menu);
 
-	Long countByIdIn(Long storeId, List<Long> menuIds);
+	Long countByIdIn(Long storeId, Set<Long> menuIds);
 
 	Optional<MenuInfo> getMenuInfoById(Long menuId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/repository/MenuRepository.java
@@ -3,7 +3,6 @@ package domain.pos.menu.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
@@ -20,15 +19,19 @@ public interface MenuRepository {
 
 	List<Menu> getAllByStoreIdWithCategoryAndLock(Long storeId);
 
-	Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId);
+	Slice<MenuInfo> getMenuSlice(int pageSize, MenuInfo lastMenuInfo, Long menuCategoryId);
+
+	boolean existsMenu(Long storeId, Long menuId);
 
 	boolean existsMenuOrder(Long menuCategoryId, Integer menuOrder);
 
-	MenuInfo patchMenu(MenuInfo patchMenuInfo);
+	MenuInfo patchMenuInfo(MenuInfo patchMenuInfo);
 
 	MenuInfo patchMenuOrder(Menu menu, Integer patchOrder);
 
 	void deleteMenu(Menu menu);
+
+	Long countByIdIn(Long storeId, List<Long> menuIds);
 
 	Optional<MenuInfo> getMenuInfoById(Long menuId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuCategoryService.java
@@ -54,7 +54,6 @@ public class MenuCategoryService {
 		return menuCategoryWriter.patchMenuCategory(patchMenuCategoryInfo);
 	}
 
-	// TODO : 컨트롤러에서 patchOrder not null 및 양수체크
 	@Transactional
 	public MenuCategoryInfo patchMenuCategoryOrder(Long storeId, UserPassport userPassport, Long menuCategoryId,
 		Integer patchOrder) {
@@ -66,6 +65,7 @@ public class MenuCategoryService {
 		return menuCategoryWriter.patchMenuCategoryOrder(storeId, menuCategoryInfo, patchOrder);
 	}
 
+	@Transactional
 	public void deleteMenuCategory(Long storeId, UserPassport userPassport, Long categoryId) {
 		Store store = storeValidator.validateStoreOwner(userPassport, storeId);
 		validateStoreOpen(store);

--- a/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/menu/service/MenuService.java
@@ -1,6 +1,5 @@
 package domain.pos.menu.service;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +52,7 @@ public class MenuService {
 			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
 	}
 
-	public Slice<MenuInfo> getMenuSlice(Pageable pageable, Long lastMenuId, Long storeId, Long menuCategoryId) {
+	public Slice<MenuInfo> getMenuSlice(int pageSize, Long lastMenuId, Long storeId, Long menuCategoryId) {
 		storeReader.readSingleStore(storeId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.NOT_FOUND_STORE));
 		menuCategoryValidator.validateMenuCategory(storeId, menuCategoryId);
@@ -63,20 +62,19 @@ public class MenuService {
 			lastMenuInfo = menuReader.getMenuInfo(storeId, lastMenuId)
 				.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
 		}
-		return menuReader.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+		return menuReader.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId);
 	}
 
 	@Transactional
-	public MenuInfo patchMenu(Long storeId, UserPassport userPassport, MenuInfo patchMenuInfo) {
+	public MenuInfo patchMenuInfo(Long storeId, UserPassport userPassport, MenuInfo patchMenuInfo) {
 		Store store = storeValidator.validateStoreOwner(userPassport, storeId);
 		validateStoreOpen(store);
 
 		menuReader.getMenuInfo(storeId, patchMenuInfo.getId())
 			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
-		return menuWriter.patchMenu(patchMenuInfo);
+		return menuWriter.patchMenuInfo(patchMenuInfo);
 	}
 
-	// TODO : 컨트롤러에서 patchOrder not null 및 양수체크
 	@Transactional
 	public MenuInfo patchMenuOrder(Long storeId, UserPassport userPassport, Long menuId,
 		Integer patchOrder) {
@@ -95,7 +93,7 @@ public class MenuService {
 		MenuInfo menuInfo = menuReader.getMenuInfo(storeId, menuId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
 		menuInfo.updateSoldOut(isSoldOut);
-		return menuWriter.patchMenu(menuInfo);
+		return menuWriter.patchMenuInfo(menuInfo);
 	}
 
 	@Transactional

--- a/domain/domain-pos/src/main/java/domain/pos/order/entity/Order.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/entity/Order.java
@@ -32,4 +32,8 @@ public class Order {
 	public static Order from(Long orderId) {
 		return new Order(orderId);
 	}
+
+	public void setOrderStatus(OrderStatus orderStatus) {
+		this.orderStatus = orderStatus;
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/entity/OrderMenu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/entity/OrderMenu.java
@@ -25,7 +25,7 @@ public class OrderMenu {
 
 	public static OrderMenu of(CartMenu cartMenu, Order order) {
 		return OrderMenu.builder()
-			.orderMenuStatus(null)
+			.orderMenuStatus(OrderMenuStatus.ORDERED)
 			.quantity(cartMenu.getQuantity())
 			.order(order)
 			.menu(Menu.of(cartMenu.getMenuInfo(), null, null))

--- a/domain/domain-pos/src/main/java/domain/pos/order/entity/OrderMenu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/entity/OrderMenu.java
@@ -1,21 +1,42 @@
 package domain.pos.order.entity;
 
+import domain.pos.cart.entity.CartMenu;
 import domain.pos.menu.entity.Menu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class OrderMenu {
 	private Long orderMenuId;
+	private OrderMenuStatus orderMenuStatus;
 	private Integer quantity;
 	private Order order;
 	private Menu menu;
 
 	@Builder
-	public OrderMenu(Long orderMenuId, Integer quantity, Order order, Menu menu) {
+	public OrderMenu(Long orderMenuId, OrderMenuStatus orderMenuStatus, Integer quantity, Order order, Menu menu) {
 		this.orderMenuId = orderMenuId;
+		this.orderMenuStatus = orderMenuStatus;
 		this.quantity = quantity;
 		this.order = order;
 		this.menu = menu;
+	}
+
+	public static OrderMenu of(CartMenu cartMenu, Order order) {
+		return OrderMenu.builder()
+			.orderMenuStatus(null)
+			.quantity(cartMenu.getQuantity())
+			.order(order)
+			.menu(Menu.of(cartMenu.getMenuInfo(), null, null))
+			.build();
+	}
+
+	public void setQuantity(Integer quantity) {
+		this.quantity = quantity;
+	}
+
+	public void setOrderMenuStatus(OrderMenuStatus orderMenuStatus) {
+		this.orderMenuStatus = orderMenuStatus;
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/entity/vo/OrderMenuStatus.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/entity/vo/OrderMenuStatus.java
@@ -1,0 +1,86 @@
+package domain.pos.order.entity.vo;
+
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum OrderMenuStatus {
+	ORDERED {
+		@Override
+		public void reCookingOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 조리중이 되었습니다 : orderMenuId={}", orderMenuId);
+		}
+
+		@Override
+		public void cancelOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 취소되었습니다 : orderMenuId={}", orderMenuId);
+		}
+
+		@Override
+		public void completeOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 완료되었습니다 : orderMenuId={}", orderMenuId);
+		}
+	},
+	COOKING {
+		@Override
+		public void reCookingOrderMenu(Long orderMenuId) {
+			log.warn("이미 조리중인 메뉴입니다 : orderMenuId={}", orderMenuId);
+			throw new ServiceException(ErrorCode.ALREADY_COOKING_ORDER_MENU);
+		}
+
+		@Override
+		public void cancelOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 취소되었습니다 : orderMenuId={}", orderMenuId);
+		}
+
+		@Override
+		public void completeOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 완료되었습니다 : orderMenuId={}", orderMenuId);
+		}
+	},
+	CANCELED {
+		@Override
+		public void reCookingOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 조리중이 되었습니다 : orderMenuId={}", orderMenuId);
+		}
+
+		@Override
+		public void cancelOrderMenu(Long orderMenuId) {
+			log.warn("이미 취소된 메뉴입니다 : orderMenuId={}", orderMenuId);
+			throw new ServiceException(ErrorCode.ALREADY_CANCELED_ORDER_MENU);
+		}
+
+		@Override
+		public void completeOrderMenu(Long orderMenuId) {
+			log.warn("이미 취소된 메뉴입니다 : orderMenuId={}", orderMenuId);
+			throw new ServiceException(ErrorCode.ALREADY_CANCELED_ORDER_MENU);
+		}
+	},
+	COMPLETED {
+		@Override
+		public void reCookingOrderMenu(Long orderMenuId) {
+			log.info("점주에 의해 주문 메뉴가 조리중이 되었습니다 : orderMenuId={}", orderMenuId);
+		}
+
+		@Override
+		public void cancelOrderMenu(Long orderMenuId) {
+			log.warn("이미 완료된 메뉴입니다 : orderMenuId={}", orderMenuId);
+			throw new ServiceException(ErrorCode.ALREADY_COMPLETED_ORDER_MENU);
+		}
+
+		@Override
+		public void completeOrderMenu(Long orderMenuId) {
+			log.warn("이미 완료된 메뉴입니다 : orderMenuId={}", orderMenuId);
+			throw new ServiceException(ErrorCode.ALREADY_COMPLETED_ORDER_MENU);
+		}
+	};
+
+	public abstract void reCookingOrderMenu(Long orderMenuId);
+
+	public abstract void cancelOrderMenu(Long orderMenuId);
+
+	public abstract void completeOrderMenu(Long orderMenuId);
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/order/entity/vo/OrderStatus.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/entity/vo/OrderStatus.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 public enum OrderStatus {
 	ORDERED {
 		@Override
-		public void receivedOrder(Long orderId, UserRole requesterRole) {
+		public void receiveOrder(Long orderId, UserRole requesterRole) {
 			if (requesterRole.equals(UserRole.ROLE_OWNER)) {
 				log.info("주문이 접수되었습니다 : orderId={}", orderId);
 			} else {
@@ -20,7 +20,7 @@ public enum OrderStatus {
 		}
 
 		@Override
-		public void cancelledOrder(Long orderId, UserRole requesterRole) {
+		public void cancelOrder(Long orderId, UserRole requesterRole) {
 			if (requesterRole.equals(UserRole.ROLE_OWNER)) {
 				log.info("점주에 의해 주문이 취소되었습니다 : orderId={}", orderId);
 			} else {
@@ -29,20 +29,19 @@ public enum OrderStatus {
 		}
 
 		@Override
-		public void completedOrder(Long orderId, UserRole requesterRole) {
-			log.warn("주문이 완료될 수 없는 상태입니다 : orderId={}", orderId);
-			throw new ServiceException(ErrorCode.INVALID_STATE_TRANSITION);
+		public OrderMenuStatus transferOrderMenuStatus() {
+			return OrderMenuStatus.ORDERED;
 		}
 	},
 	RECEIVED {
 		@Override
-		public void receivedOrder(Long orderId, UserRole requesterRole) {
+		public void receiveOrder(Long orderId, UserRole requesterRole) {
 			log.warn("이미 점주가 접수한 주문입니다 : orderId={}", orderId);
 			throw new ServiceException(ErrorCode.ALREADY_RECEIVED_ORDER);
 		}
 
 		@Override
-		public void cancelledOrder(Long orderId, UserRole requesterRole) {
+		public void cancelOrder(Long orderId, UserRole requesterRole) {
 			if (requesterRole.equals(UserRole.ROLE_OWNER)) {
 				log.info("점주에 의해 주문이 취소되었습니다 : orderId={}", orderId);
 			} else {
@@ -52,43 +51,38 @@ public enum OrderStatus {
 		}
 
 		@Override
-		public void completedOrder(Long orderId, UserRole requesterRole) {
-			if (requesterRole.equals(UserRole.ROLE_OWNER)) {
-				log.info("주문 서빙이 완료되었습니다 : orderId={}", orderId);
-			} else {
-				log.warn("주문 서빙을 완료할 수 있는 권한이 없습니다 : orderId={}", orderId);
-				throw new ServiceException(ErrorCode.ORDER_ACCESS_DENIED);
-			}
+		public OrderMenuStatus transferOrderMenuStatus() {
+			return OrderMenuStatus.COOKING;
 		}
 	},
-	CANCELLED {
+	CANCELED {
 		@Override
-		public void receivedOrder(Long orderId, UserRole requesterRole) {
+		public void receiveOrder(Long orderId, UserRole requesterRole) {
 			log.warn("이미 취소된 주문입니다 : orderId={}", orderId);
-			throw new ServiceException(ErrorCode.ALREADY_CANCELLED_ORDER);
+			throw new ServiceException(ErrorCode.ALREADY_CANCELED_ORDER);
 		}
 
 		@Override
-		public void cancelledOrder(Long orderId, UserRole requesterRole) {
+		public void cancelOrder(Long orderId, UserRole requesterRole) {
 			log.warn("이미 취소된 주문입니다 : orderId={}", orderId);
-			throw new ServiceException(ErrorCode.ALREADY_CANCELLED_ORDER);
+			throw new ServiceException(ErrorCode.ALREADY_CANCELED_ORDER);
 		}
 
 		@Override
-		public void completedOrder(Long orderId, UserRole requesterRole) {
-			log.warn("이미 취소된 주문입니다 : orderId={}", orderId);
-			throw new ServiceException(ErrorCode.ALREADY_CANCELLED_ORDER);
+		public OrderMenuStatus transferOrderMenuStatus() {
+			return OrderMenuStatus.CANCELED;
 		}
+
 	},
 	COMPLETED {
 		@Override
-		public void receivedOrder(Long orderId, UserRole requesterRole) {
+		public void receiveOrder(Long orderId, UserRole requesterRole) {
 			log.warn("이미 완료된 주문입니다 : orderId={}", orderId);
 			throw new ServiceException(ErrorCode.ALREADY_COMPLETED_ORDER);
 		}
 
 		@Override
-		public void cancelledOrder(Long orderId, UserRole requesterRole) {
+		public void cancelOrder(Long orderId, UserRole requesterRole) {
 			if (requesterRole.equals(UserRole.ROLE_OWNER)) {
 				log.info("점주에 의해 주문이 취소되었습니다 : orderId={}", orderId);
 			} else {
@@ -98,15 +92,14 @@ public enum OrderStatus {
 		}
 
 		@Override
-		public void completedOrder(Long orderId, UserRole requesterRole) {
-			log.warn("이미 완료된 주문입니다 : orderId={}", orderId);
-			throw new ServiceException(ErrorCode.ALREADY_COMPLETED_ORDER);
+		public OrderMenuStatus transferOrderMenuStatus() {
+			return OrderMenuStatus.COMPLETED;
 		}
 	};
 
-	public abstract void receivedOrder(Long orderId, UserRole requesterRole);
+	public abstract void receiveOrder(Long orderId, UserRole requesterRole);
 
-	public abstract void cancelledOrder(Long orderId, UserRole requesterRole);
+	public abstract void cancelOrder(Long orderId, UserRole requesterRole);
 
-	public abstract void completedOrder(Long orderId, UserRole requesterRole);
+	public abstract OrderMenuStatus transferOrderMenuStatus();
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/event/OrderEventListener.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/event/OrderEventListener.java
@@ -1,0 +1,22 @@
+package domain.pos.order.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import domain.pos.order.implement.OrderMenuReader;
+import domain.pos.order.implement.OrderWriter;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderEventListener {
+	private final OrderMenuReader orderMenuReader;
+	private final OrderWriter orderWriter;
+
+	@EventListener
+	public void handleOrderEvent(OrderMenuStatusChangedEvent event) {
+		if (!orderMenuReader.existsCookingMenu(event.getOrder().getOrderId())) {
+			orderWriter.completeOrder(event.getOrder());
+		}
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/order/event/OrderMenuStatusChangedEvent.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/event/OrderMenuStatusChangedEvent.java
@@ -1,0 +1,17 @@
+package domain.pos.order.event;
+
+import domain.pos.order.entity.Order;
+import lombok.Getter;
+
+@Getter
+public class OrderMenuStatusChangedEvent {
+	private final Order order;
+
+	private OrderMenuStatusChangedEvent(Order order) {
+		this.order = order;
+	}
+
+	public static OrderMenuStatusChangedEvent from(Order order) {
+		return new OrderMenuStatusChangedEvent(order);
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderMenuReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderMenuReader.java
@@ -13,8 +13,12 @@ import lombok.RequiredArgsConstructor;
 public class OrderMenuReader {
 	private final OrderMenuRepository orderMenuRepository;
 
-	public Optional<OrderMenu> getOrderMenuWithStore(Long orderMenuId) {
-		return orderMenuRepository.getOrderMenuWithStore(orderMenuId);
+	public Optional<OrderMenu> getOrderMenuWithOrderAndStore(Long orderMenuId) {
+		return orderMenuRepository.getOrderMenuWithOrderAndStore(orderMenuId);
+	}
+
+	public boolean existsCookingMenu(Long orderId) {
+		return orderMenuRepository.existsCookingMenu(orderId);
 	}
 
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderMenuWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderMenuWriter.java
@@ -2,24 +2,44 @@ package domain.pos.order.implement;
 
 import org.springframework.stereotype.Component;
 
+import com.exception.ErrorCode;
+import com.exception.ServiceException;
+
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
 import domain.pos.order.repository.OrderMenuRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class OrderMenuWriter {
 	private final OrderMenuRepository orderMenuRepository;
 
-	public OrderMenu postOrderMenu(Long orderId, OrderMenu orderMenu) {
-		return orderMenuRepository.postOrderMenu(orderId, orderMenu);
+	public OrderMenu patchOrderMenuStatus(OrderMenu orderMenu, OrderMenuStatus orderMenuStatus) {
+		if (orderMenuStatus == OrderMenuStatus.COOKING) {
+			orderMenu.getOrderMenuStatus().reCookingOrderMenu(orderMenu.getOrderMenuId());
+		} else if (orderMenuStatus == OrderMenuStatus.CANCELED) {
+			orderMenu.getOrderMenuStatus().cancelOrderMenu(orderMenu.getOrderMenuId());
+		} else if (orderMenuStatus == OrderMenuStatus.COMPLETED) {
+			orderMenu.getOrderMenuStatus().completeOrderMenu(orderMenu.getOrderMenuId());
+		} else {
+			log.warn("올바른 변경 요청이 아닙니다 : orderMenuStatus={}", orderMenuStatus);
+			throw new ServiceException(ErrorCode.INVALID_STATE_TRANSITION);
+		}
+
+		return orderMenuRepository.patchOrderMenuStatus(orderMenu, orderMenuStatus);
 	}
 
-	public OrderMenu patchOrderMenuQuantity(OrderMenu orderMenu, int quantity) {
-		return orderMenuRepository.patchOrderMenuQuantity(orderMenu, quantity);
+	public OrderMenu postOrderMenu(MenuInfo menuInfo, Integer quantity, Order order) {
+		return orderMenuRepository.postOrderMenu(menuInfo, quantity, order);
 	}
 
-	public void deleteOrderMenu(Long orderMenuId) {
-		orderMenuRepository.deleteOrderMenu(orderMenuId);
+	public void deleteOrderMenu(OrderMenu orderMenu) {
+		orderMenuRepository.deleteOrderMenu(orderMenu);
 	}
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderReader.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import domain.pos.order.entity.Order;
+import domain.pos.order.entity.vo.OrderStatus;
 import domain.pos.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -14,15 +15,19 @@ import lombok.RequiredArgsConstructor;
 public class OrderReader {
 	private final OrderRepository orderRepository;
 
-	public Optional<Order> getOrder(Long orderId) {
-		return orderRepository.getOrder(orderId);
+	public Optional<Order> getOrderWithMenu(Long orderId) {
+		return orderRepository.getOrderWithMenu(orderId);
 	}
 
 	public Optional<Order> getOrderWithStore(Long orderId) {
 		return orderRepository.getOrderWithStore(orderId);
 	}
 
-	public List<Order> getReceiptOrders(Long receiptId) {
-		return orderRepository.getReceiptOrders(receiptId);
+	public List<Order> getSaleOrdersWithMenuAndTable(Long saleId, List<OrderStatus> orderStatuses) {
+		return orderRepository.getSaleOrdersWithMenuAndTable(saleId, orderStatuses);
+	}
+
+	public List<Order> getReceiptOrdersWithMenu(Long receiptId) {
+		return orderRepository.getReceiptOrdersWithMenu(receiptId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderWriter.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Component;
 import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
+import domain.pos.cart.entity.CartMenu;
 import domain.pos.member.entity.UserRole;
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
 import domain.pos.order.entity.vo.OrderStatus;
 import domain.pos.order.repository.OrderRepository;
+import domain.pos.receipt.entity.Receipt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,22 +23,28 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderWriter {
 	private final OrderRepository orderRepository;
 
-	public Order postOrder(Long receiptId, List<OrderMenu> orderMenus) {
-		return orderRepository.postOrder(receiptId, orderMenus);
+	public Order postOrderWithCart(Receipt receipt, List<CartMenu> cartMenus) {
+		return orderRepository.postOrderWithCart(receipt, cartMenus);
+	}
+
+	public Order postOrderWithoutCart(Receipt receipt, List<OrderMenu> orderMenus) {
+		return orderRepository.postOrderWithoutCart(receipt, orderMenus);
 	}
 
 	public Order patchOrderStatus(Order order, OrderStatus orderStatus, UserRole userRole) {
 		if (orderStatus == OrderStatus.RECEIVED) {
-			order.getOrderStatus().receivedOrder(order.getOrderId(), userRole);
-		} else if (orderStatus == OrderStatus.CANCELLED) {
-			order.getOrderStatus().cancelledOrder(order.getOrderId(), userRole);
-		} else if (orderStatus == OrderStatus.COMPLETED) {
-			order.getOrderStatus().completedOrder(order.getOrderId(), userRole);
+			order.getOrderStatus().receiveOrder(order.getOrderId(), userRole);
+		} else if (orderStatus == OrderStatus.CANCELED) {
+			order.getOrderStatus().cancelOrder(order.getOrderId(), userRole);
 		} else {
 			log.warn("올바른 변경 요청이 아닙니다 : orderStatus={}", orderStatus);
 			throw new ServiceException(ErrorCode.INVALID_STATE_TRANSITION);
 		}
 
 		return orderRepository.patchOrderStatus(order, orderStatus);
+	}
+
+	public void completeOrder(Order order) {
+		orderRepository.patchOrderStatus(order, OrderStatus.COMPLETED);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/implement/OrderWriter.java
@@ -45,6 +45,7 @@ public class OrderWriter {
 	}
 
 	public void completeOrder(Order order) {
+		order.setOrderStatus(OrderStatus.COMPLETED);
 		orderRepository.patchOrderStatus(order, OrderStatus.COMPLETED);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/repository/OrderMenuRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/repository/OrderMenuRepository.java
@@ -2,14 +2,22 @@ package domain.pos.order.repository;
 
 import java.util.Optional;
 
+import org.springframework.stereotype.Repository;
+
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
 
+@Repository
 public interface OrderMenuRepository {
-	OrderMenu postOrderMenu(Long orderId, OrderMenu orderMenu);
+	OrderMenu postOrderMenu(MenuInfo menuInfo, Integer quantity, Order order);
 
-	Optional<OrderMenu> getOrderMenuWithStore(Long orderMenuId);
+	Optional<OrderMenu> getOrderMenuWithOrderAndStore(Long orderMenuId);
 
-	OrderMenu patchOrderMenuQuantity(OrderMenu orderMenu, int quantity);
+	void deleteOrderMenu(OrderMenu orderMenu);
 
-	void deleteOrderMenu(Long orderMenuId);
+	OrderMenu patchOrderMenuStatus(OrderMenu orderMenu, OrderMenuStatus orderMenuStatus);
+
+	boolean existsCookingMenu(Long orderId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/repository/OrderRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/repository/OrderRepository.java
@@ -5,20 +5,25 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import domain.pos.cart.entity.CartMenu;
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
 import domain.pos.order.entity.vo.OrderStatus;
+import domain.pos.receipt.entity.Receipt;
 
 @Repository
 public interface OrderRepository {
-	// TODO : 인프라 단에서 모듣 메뉴 금액 계산 후 엔티티 저장 시 반영해야함 + orderMenu에 조회한 Menu 엔티티를 직접 넣어야함(응답에 포함되어야하므로)
-	Order postOrder(Long receiptId, List<OrderMenu> orderMenus);
+	Order postOrderWithCart(Receipt receipt, List<CartMenu> cartMenus);
 
-	Optional<Order> getOrder(Long orderId);
+	Order postOrderWithoutCart(Receipt receipt, List<OrderMenu> orderMenus);
+
+	Optional<Order> getOrderWithMenu(Long orderId);
 
 	Optional<Order> getOrderWithStore(Long orderId);
 
 	Order patchOrderStatus(Order order, OrderStatus orderStatus);
 
-	List<Order> getReceiptOrders(Long receiptId);
+	List<Order> getSaleOrdersWithMenuAndTable(Long saleId, List<OrderStatus> orderStatuses);
+
+	List<Order> getReceiptOrdersWithMenu(Long receiptId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/service/OrderMenuService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/service/OrderMenuService.java
@@ -1,5 +1,6 @@
 package domain.pos.order.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,9 +8,14 @@ import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
 import domain.pos.member.entity.UserPassport;
+import domain.pos.member.entity.UserRole;
+import domain.pos.menu.entity.MenuInfo;
 import domain.pos.menu.implement.MenuReader;
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
+import domain.pos.order.entity.vo.OrderStatus;
+import domain.pos.order.event.OrderMenuStatusChangedEvent;
 import domain.pos.order.implement.OrderMenuReader;
 import domain.pos.order.implement.OrderMenuWriter;
 import domain.pos.order.implement.OrderReader;
@@ -20,36 +26,57 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderMenuService {
 	private final ReceiptValidator receiptValidator;
-
 	private final OrderReader orderReader;
 	private final MenuReader menuReader;
-
 	private final OrderMenuReader orderMenuReader;
 	private final OrderMenuWriter orderMenuWriter;
 
+	private final ApplicationEventPublisher eventPublisher;
+
 	@Transactional
-	public OrderMenu postOrderMenu(Long orderId, UserPassport userPassport, OrderMenu orderMenu) {
+	public OrderMenu patchOrderMenuStatus(Long orderMenuId, UserPassport userPassport,
+		OrderMenuStatus orderMenuStatus) {
+		OrderMenu orderMenu = orderMenuReader.getOrderMenuWithOrderAndStore(orderMenuId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_MENU_NOT_FOUND));
+		validateOrderStatus(orderMenu.getOrder());
+		validateIsOwner(orderMenu, userPassport);
+
+		OrderMenu patchOrderMenu = orderMenuWriter.patchOrderMenuStatus(orderMenu, orderMenuStatus);
+
+		if (orderMenuStatus == OrderMenuStatus.CANCELED || orderMenuStatus == OrderMenuStatus.COMPLETED) {
+			eventPublisher.publishEvent(OrderMenuStatusChangedEvent.from(orderMenu.getOrder()));
+		}
+		return patchOrderMenu;
+	}
+
+	@Transactional
+	public OrderMenu postOrderMenu(Long orderId, UserPassport userPassport, Long menuId, Integer quantity) {
 		Order order = orderReader.getOrderWithStore(orderId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
 		receiptValidator.validateIsOwner(order.getReceipt(), userPassport);
-		menuReader.getMenuInfo(order.getReceipt().getSale().getStore().getStoreId(),
-				orderMenu.getMenu().getMenuInfo().getId())
+		MenuInfo menuInfo = menuReader.getMenuInfo(order.getReceipt().getSale().getStore().getStoreId(), menuId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
-		return orderMenuWriter.postOrderMenu(orderId, orderMenu);
+		return orderMenuWriter.postOrderMenu(menuInfo, quantity, order);
 	}
 
 	@Transactional
-	public OrderMenu patchOrderMenuQuantity(Long orderMenuId, UserPassport userPassport, Integer quantity) {
-		OrderMenu orderMenu = orderMenuReader.getOrderMenuWithStore(orderMenuId)
+	public void deleteOrderMenu(Long orderMenuId, UserPassport userPassport) {
+		OrderMenu orderMenu = orderMenuReader.getOrderMenuWithOrderAndStore(orderMenuId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_MENU_NOT_FOUND));
-		receiptValidator.validateIsOwner(orderMenu.getOrder().getReceipt(), userPassport);
-		return orderMenuWriter.patchOrderMenuQuantity(orderMenu, quantity);
+		validateIsOwner(orderMenu, userPassport);
+		orderMenuWriter.deleteOrderMenu(orderMenu);
 	}
 
-	public void deleteOrderMenu(Long orderMenuId, UserPassport userPassport) {
-		OrderMenu orderMenu = orderMenuReader.getOrderMenuWithStore(orderMenuId)
-			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_MENU_NOT_FOUND));
-		receiptValidator.validateIsOwner(orderMenu.getOrder().getReceipt(), userPassport);
-		orderMenuWriter.deleteOrderMenu(orderMenuId);
+	private void validateIsOwner(OrderMenu orderMenu, UserPassport userPassport) {
+		if (!orderMenu.getMenu().getStore().getOwnerPassport().getUserId().equals(userPassport.getUserId())
+			|| userPassport.getUserRole() != UserRole.ROLE_OWNER) {
+			throw new ServiceException(ErrorCode.ORDER_MENU_ACCESS_DENIED);
+		}
+	}
+
+	private void validateOrderStatus(Order order) {
+		if (order.getOrderStatus() != OrderStatus.RECEIVED) {
+			throw new ServiceException(ErrorCode.ORDER_STATUS_NOT_RECEIVED);
+		}
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/service/OrderService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/service/OrderService.java
@@ -8,8 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
+import domain.pos.cart.entity.Cart;
+import domain.pos.cart.entity.CartMenu;
+import domain.pos.cart.implement.CartWriter;
 import domain.pos.member.entity.UserPassport;
 import domain.pos.member.entity.UserRole;
+import domain.pos.menu.entity.MenuInfo;
 import domain.pos.menu.implement.MenuReader;
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
@@ -20,6 +24,8 @@ import domain.pos.receipt.entity.Receipt;
 import domain.pos.receipt.implement.ReceiptCustomerWriter;
 import domain.pos.receipt.implement.ReceiptReader;
 import domain.pos.receipt.implement.ReceiptValidator;
+import domain.pos.store.entity.Sale;
+import domain.pos.store.implement.SaleReader;
 import domain.pos.store.implement.SaleValidator;
 import lombok.RequiredArgsConstructor;
 
@@ -33,47 +39,102 @@ public class OrderService {
 	private final MenuReader menuReader;
 	private final OrderWriter orderWriter;
 	private final OrderReader orderReader;
+	private final CartWriter cartWriter;
+	private final SaleReader saleReader;
 
 	// TODO : 위치기반으로 특정 범위 내에 유저가 존재해야만 주문이 가능하도록 구현 필요
 	@Transactional
-	public Order postOrder(Long receiptId, UserPassport userPassport, List<OrderMenu> orderMenus) {
-		List<Receipt> receipts = receiptReader.getNonStopReceiptsWithStoreAndLock(List.of(receiptId));
-		if (receipts.isEmpty()) {
-			throw new ServiceException(ErrorCode.RECEIPT_NOT_FOUND);
-		}
-		Receipt receipt = receipts.get(0);
+	public Order postOrderWithCart(Long receiptId, UserPassport userPassport) {
+		Receipt receipt = receiptReader.getNonStopReceiptsWithTableAndStoreAndLock(receiptId).orElseThrow(
+			() -> new ServiceException(ErrorCode.RECEIPT_NOT_FOUND));
 
+		// 영업 상태 검증
 		saleValidator.validateSaleOpen(receipt.getSale());
 
-		Long storeId = receipt.getSale().getStore().getStoreId();
-		for (OrderMenu orderMenu : orderMenus) {
-			menuReader.getMenuInfo(storeId, orderMenu.getMenu().getMenuInfo().getId())
-				.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+		// 장바구니 조회 및 장바구니 메뉴 존재 검증
+		Cart cart = cartWriter.getCart(receiptId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.CART_NOT_FOUND));
+		if (cart.getCartMenus().isEmpty()) {
+			throw new ServiceException(ErrorCode.CART_EMPTY);
 		}
 
+		// 모든 장바구니 메뉴가 store에 해당하는 메뉴인지 검증
+		Long storeId = receipt.getSale().getStore().getStoreId();
+		List<Long> menuIds = cart.getCartMenus().stream()
+			.map(cartMenu -> cartMenu.getMenuInfo().getId())
+			.toList();
+		if (menuReader.countByIdIn(storeId, menuIds) != menuIds.size()) {
+			throw new ServiceException(ErrorCode.MENU_NOT_FOUND);
+		}
+
+		// 품절 여부 검증
+		for (CartMenu cartMenu : cart.getCartMenus()) {
+			if (cartMenu.getMenuInfo().isSoldOut()) {
+				throw new ServiceException(ErrorCode.MENU_SOLD_OUT);
+			}
+		}
+
+		// 로그인 유저의 주문일 경우, 주문자 정보 등록
 		if (userPassport.getUserRole().isHigherOrEqual(UserRole.ROLE_USER)
 			&& !receiptValidator.isStoreOwner(receipt, userPassport)) {
 			receiptCustomerWriter.postReceiptCustomer(userPassport.getUserId(), receiptId);
 		}
-		return orderWriter.postOrder(receiptId, orderMenus);
+
+		Order order = orderWriter.postOrderWithCart(receipt, cart.getCartMenus());
+		cartWriter.deleteCartAndCartMenuByReceiptId(receiptId);
+		return order;
 	}
 
 	@Transactional
+	public Order postOrderWithoutCart(Long receiptId, UserPassport userPassport, List<OrderMenu> orderMenus) {
+		Receipt receipt = receiptReader.getNonStopReceiptsWithTableAndStoreAndLock(receiptId).orElseThrow(
+			() -> new ServiceException(ErrorCode.RECEIPT_NOT_FOUND));
+
+		saleValidator.validateSaleOpen(receipt.getSale());
+		receiptValidator.validateIsOwner(receipt, userPassport);
+
+		Long storeId = receipt.getSale().getStore().getStoreId();
+		for (OrderMenu orderMenu : orderMenus) {
+			MenuInfo menuInfo = menuReader.getMenuInfo(storeId, orderMenu.getMenu().getMenuInfo().getId())
+				.orElseThrow(() -> new ServiceException(ErrorCode.MENU_NOT_FOUND));
+			orderMenu.getMenu().changeFullInfoMenuInfo(menuInfo);
+
+			if (menuInfo.isSoldOut()) {
+				throw new ServiceException(ErrorCode.MENU_SOLD_OUT);
+			}
+		}
+
+		return orderWriter.postOrderWithoutCart(receipt, orderMenus);
+	}
+
+	// 주문 취소, 주문 접수만 가능
 	public Order patchOrderStatus(Long orderId, UserPassport userPassport, OrderStatus orderStatus) {
 		Order order = orderReader.getOrderWithStore(orderId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
 
 		UserRole userRole = receiptValidator.validateRole(order.getReceipt(), userPassport);
+
 		return orderWriter.patchOrderStatus(order, orderStatus, userRole);
 	}
 
 	public List<Order> getReceiptOrders(Long receiptId) {
 		receiptValidator.validateReceipt(receiptId);
-		return orderReader.getReceiptOrders(receiptId);
+		return orderReader.getReceiptOrdersWithMenu(receiptId);
+	}
+
+	public List<Order> getSaleOrders(Long saleId, List<OrderStatus> orderStatuses, UserPassport userPassport) {
+		Sale sale = saleReader.readSingleSale(saleId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.NOT_FOUND_SALE));
+		if (!sale.getStore().getOwnerPassport().getUserId().equals(userPassport.getUserId())
+			|| userPassport.getUserRole() != UserRole.ROLE_OWNER) {
+			throw new ServiceException(ErrorCode.SALE_ACCESS_DENIED);
+		}
+
+		return orderReader.getSaleOrdersWithMenuAndTable(saleId, orderStatuses);
 	}
 
 	public Order getOrder(Long orderId) {
-		return orderReader.getOrder(orderId)
+		return orderReader.getOrderWithMenu(orderId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/order/service/OrderService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/order/service/OrderService.java
@@ -1,6 +1,8 @@
 package domain.pos.order.service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,9 +62,9 @@ public class OrderService {
 
 		// 모든 장바구니 메뉴가 store에 해당하는 메뉴인지 검증
 		Long storeId = receipt.getSale().getStore().getStoreId();
-		List<Long> menuIds = cart.getCartMenus().stream()
+		Set<Long> menuIds = cart.getCartMenus().stream()
 			.map(cartMenu -> cartMenu.getMenuInfo().getId())
-			.toList();
+			.collect(Collectors.toSet());
 		if (menuReader.countByIdIn(storeId, menuIds) != menuIds.size()) {
 			throw new ServiceException(ErrorCode.MENU_NOT_FOUND);
 		}

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/implement/ReceiptReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/implement/ReceiptReader.java
@@ -38,6 +38,10 @@ public class ReceiptReader {
 		return receiptRepository.getStopReceiptsWithTableAndStore(receiptIds);
 	}
 
+	public Optional<Receipt> getNonStopReceiptsWithTableAndStoreAndLock(Long receiptId) {
+		return receiptRepository.getNonStopReceiptsWithTableAndStoreAndLock(receiptId);
+	}
+
 	public List<Receipt> getNonStopReceiptsWithStoreAndLock(List<Long> receiptIds) {
 		return receiptRepository.getNonStopReceiptsWithStoreAndLock(receiptIds);
 	}
@@ -50,7 +54,7 @@ public class ReceiptReader {
 		return receiptRepository.getNonAdjustReceipt(tableId);
 	}
 
-	public Slice<Receipt> getCustomerReceiptSlice(Pageable pageable, Long customerId) {
-		return receiptRepository.getCustomerReceiptSlice(pageable, customerId);
+	public Slice<Receipt> getCustomerReceiptSlice(int pageSize, Long lastReceiptId, Long customerId) {
+		return receiptRepository.getCustomerReceiptSlice(pageSize, lastReceiptId, customerId);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/repository/ReceiptRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/repository/ReceiptRepository.java
@@ -25,13 +25,15 @@ public interface ReceiptRepository {
 
 	List<Receipt> getStopReceiptsWithStore(List<Long> receiptIds);
 
+	Optional<Receipt> getNonStopReceiptsWithTableAndStoreAndLock(Long receiptId);
+
 	List<Receipt> getNonStopReceiptsWithStoreAndLock(List<Long> receiptIds);
 
 	Page<ReceiptInfo> getAdjustedReceiptPageBySale(Pageable pageable, Long saleId);
 
 	ReceiptInfo getNonAdjustReceipt(Long tableId);
 
-	Slice<Receipt> getCustomerReceiptSlice(Pageable pageable, Long customerId);
+	Slice<Receipt> getCustomerReceiptSlice(int pageSize, Long lastReceiptId, Long customerId);
 
 	boolean existsReceipt(Long receiptId);
 

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/service/ReceiptService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/service/ReceiptService.java
@@ -73,7 +73,6 @@ public class ReceiptService {
 			});
 	}
 
-	// TODO : application 계층 one-indexed-parameters 설정 추가
 	// Owner api
 	public Page<ReceiptInfo> getAdjustedReceiptPageBySale(Pageable pageable, UserPassport userPassport, Long saleId) {
 		Sale sale = saleReader.readSingleSale(saleId)
@@ -158,9 +157,16 @@ public class ReceiptService {
 		return receiptInfo != null ? receiptInfo.getReceiptId() : null;
 	}
 
-	public Slice<Receipt> getCustomerReceiptSlice(Pageable pageable, UserPassport userPassport, Long customerId) {
+	public Slice<Receipt> getCustomerReceiptSlice(int pageSize, UserPassport userPassport, Long customerId,
+		Long lastReceiptId) {
 		userPassportValidator.validateUserPassport(userPassport, customerId);
-		return receiptReader.getCustomerReceiptSlice(pageable, customerId);
+		if (lastReceiptId != null) {
+			if (!receiptReader.existsReceipt(lastReceiptId)) {
+				log.warn("lastReceipt 을 찾을 수 없습니다. receiptId: {}", lastReceiptId);
+				throw new ServiceException(ErrorCode.RECEIPT_NOT_FOUND);
+			}
+		}
+		return receiptReader.getCustomerReceiptSlice(pageSize, lastReceiptId, customerId);
 	}
 
 }

--- a/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/MenuServiceTest.java
@@ -297,9 +297,9 @@ public class MenuServiceTest extends ServiceTest {
 	@Nested
 	@DisplayName("메뉴 리스트 조회")
 	class getMenuSlice {
-		private final int size = 10;
+		private final int pageSize = 10;
 		private final boolean hasNext = false;
-		private final Pageable pageable = Pageable.ofSize(size);
+		private final Pageable pageable = Pageable.ofSize(pageSize);
 		private final Long lastMenuId = GENERAL_MENU_ID;
 		private final Long storeId = 1L;
 		private final Long menuCategoryId = 1L;
@@ -318,15 +318,15 @@ public class MenuServiceTest extends ServiceTest {
 				.willReturn(Optional.of(store));
 			BDDMockito.given(menuReader.getMenuInfo(storeId, lastMenuId))
 				.willReturn(Optional.of(lastMenuInfo));
-			BDDMockito.given(menuReader.getMenuSlice(pageable, lastMenuInfo, menuCategoryId))
+			BDDMockito.given(menuReader.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId))
 				.willReturn(menuSlice);
 
 			// when
-			Slice<MenuInfo> serviceMenuSlice = menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId);
+			Slice<MenuInfo> serviceMenuSlice = menuService.getMenuSlice(pageSize, lastMenuId, storeId, menuCategoryId);
 
 			// then
 			assertSoftly(softly -> {
-				softly.assertThat(serviceMenuSlice.getSize()).isEqualTo(size);
+				softly.assertThat(serviceMenuSlice.getSize()).isEqualTo(pageSize);
 				softly.assertThat(serviceMenuSlice.hasNext()).isEqualTo(hasNext);
 				softly.assertThat(serviceMenuSlice.getContent().get(0).getOrder())
 					.isEqualTo(GENERAL_MENU_ORDER + 1);
@@ -337,7 +337,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader)
 					.getMenuInfo(storeId, lastMenuId);
 				verify(menuReader)
-					.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+					.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId);
 			});
 		}
 
@@ -350,7 +350,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+						() -> menuService.getMenuSlice(pageSize, lastMenuId, storeId, menuCategoryId))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
 				verify(storeReader)
@@ -360,7 +360,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader, never())
 					.getMenuInfo(anyLong(), anyLong());
 				verify(menuReader, never())
-					.getMenuSlice(any(), any(), anyLong());
+					.getMenuSlice(anyInt(), any(), anyLong());
 			});
 		}
 
@@ -378,7 +378,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+						() -> menuService.getMenuSlice(pageSize, lastMenuId, storeId, menuCategoryId))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_CATEGORY_NOT_FOUND);
 				verify(storeReader)
@@ -388,7 +388,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader, never())
 					.getMenuInfo(anyLong(), anyLong());
 				verify(menuReader, never())
-					.getMenuSlice(any(), any(), anyLong());
+					.getMenuSlice(anyInt(), any(), anyLong());
 			});
 		}
 
@@ -404,7 +404,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.getMenuSlice(pageable, lastMenuId, storeId, menuCategoryId))
+						() -> menuService.getMenuSlice(pageSize, lastMenuId, storeId, menuCategoryId))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_FOUND);
 				verify(storeReader)
@@ -414,7 +414,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader)
 					.getMenuInfo(storeId, lastMenuId);
 				verify(menuReader, never())
-					.getMenuSlice(any(), any(), anyLong());
+					.getMenuSlice(anyInt(), any(), anyLong());
 			});
 		}
 	}
@@ -434,11 +434,11 @@ public class MenuServiceTest extends ServiceTest {
 				.willReturn(store);
 			BDDMockito.given(menuReader.getMenuInfo(storeId, patchMenuInfo.getId()))
 				.willReturn(Optional.of(patchMenuInfo));
-			BDDMockito.given(menuWriter.patchMenu(patchMenuInfo))
+			BDDMockito.given(menuWriter.patchMenuInfo(patchMenuInfo))
 				.willReturn(patchMenuInfo);
 
 			// when
-			MenuInfo servicePatchMenuInfo = menuService.patchMenu(storeId, userPassport, patchMenuInfo);
+			MenuInfo servicePatchMenuInfo = menuService.patchMenuInfo(storeId, userPassport, patchMenuInfo);
 
 			// then
 			assertSoftly(softly -> {
@@ -454,7 +454,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader)
 					.getMenuInfo(storeId, patchMenuInfo.getId());
 				verify(menuWriter)
-					.patchMenu(patchMenuInfo);
+					.patchMenuInfo(patchMenuInfo);
 			});
 		}
 
@@ -468,7 +468,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.patchMenu(storeId, userPassport, patchMenuInfo))
+						() -> menuService.patchMenuInfo(storeId, userPassport, patchMenuInfo))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
 				verify(storeValidator)
@@ -476,7 +476,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader, never())
 					.getMenuInfo(anyLong(), anyLong());
 				verify(menuWriter, never())
-					.patchMenu(any());
+					.patchMenuInfo(any());
 			});
 		}
 
@@ -490,7 +490,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.patchMenu(storeId, userPassport, patchMenuInfo))
+						() -> menuService.patchMenuInfo(storeId, userPassport, patchMenuInfo))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
 				verify(storeValidator)
@@ -498,7 +498,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader, never())
 					.getMenuInfo(anyLong(), anyLong());
 				verify(menuWriter, never())
-					.patchMenu(any());
+					.patchMenuInfo(any());
 			});
 		}
 
@@ -514,7 +514,7 @@ public class MenuServiceTest extends ServiceTest {
 			// when -> then
 			assertSoftly(softly -> {
 				softly.assertThatThrownBy(
-						() -> menuService.patchMenu(storeId, userPassport, patchMenuInfo))
+						() -> menuService.patchMenuInfo(storeId, userPassport, patchMenuInfo))
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_FOUND);
 				verify(storeValidator)
@@ -522,7 +522,7 @@ public class MenuServiceTest extends ServiceTest {
 				verify(menuReader)
 					.getMenuInfo(storeId, patchMenuInfo.getId());
 				verify(menuWriter, never())
-					.patchMenu(any());
+					.patchMenuInfo(any());
 			});
 		}
 	}

--- a/domain/domain-pos/src/test/java/domain/pos/order/implement/OrderWriterTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/order/implement/OrderWriterTest.java
@@ -115,7 +115,7 @@ public class OrderWriterTest {
 				softly.assertThatThrownBy(
 						() -> orderWriter.patchOrderStatus(order, orderStatus, userPassport.getUserRole()))
 					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_CANCELLED_ORDER);
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_CANCELED_ORDER);
 
 				verify(orderRepository, never()).patchOrderStatus(order, orderStatus);
 			});
@@ -142,7 +142,7 @@ public class OrderWriterTest {
 	@Nested
 	@DisplayName("주문 상태 CANCELLED로 변경")
 	class patchOrderStatusToCANCELLED {
-		private final OrderStatus orderStatus = OrderStatus.CANCELLED;
+		private final OrderStatus orderStatus = OrderStatus.CANCELED;
 
 		@Test
 		void ORDERED_TO_CANCELLED_점주_성공() {
@@ -211,7 +211,7 @@ public class OrderWriterTest {
 				softly.assertThatThrownBy(
 						() -> orderWriter.patchOrderStatus(order, orderStatus, userPassport.getUserRole()))
 					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_CANCELLED_ORDER);
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_CANCELED_ORDER);
 
 				verify(orderRepository, never()).patchOrderStatus(order, orderStatus);
 			});

--- a/domain/domain-pos/src/test/java/domain/pos/order/service/OrderServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/order/service/OrderServiceTest.java
@@ -3,14 +3,12 @@ package domain.pos.order.service;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -19,23 +17,20 @@ import com.exception.ErrorCode;
 import com.exception.ServiceException;
 
 import base.ServiceTest;
+import domain.pos.cart.implement.CartWriter;
 import domain.pos.member.entity.UserPassport;
 import domain.pos.menu.implement.MenuReader;
 import domain.pos.order.entity.Order;
-import domain.pos.order.entity.OrderMenu;
 import domain.pos.order.entity.vo.OrderStatus;
 import domain.pos.order.implement.OrderReader;
 import domain.pos.order.implement.OrderWriter;
-import domain.pos.receipt.entity.Receipt;
 import domain.pos.receipt.implement.ReceiptCustomerWriter;
 import domain.pos.receipt.implement.ReceiptReader;
 import domain.pos.receipt.implement.ReceiptValidator;
+import domain.pos.store.implement.SaleReader;
 import domain.pos.store.implement.SaleValidator;
 import fixtures.member.UserFixture;
-import fixtures.menu.MenuInfoFixture;
 import fixtures.order.OrderFixture;
-import fixtures.order.OrderMenuFixture;
-import fixtures.receipt.ReceiptFixture;
 import fixtures.receipt.ReceiptInfoFixture;
 
 public class OrderServiceTest extends ServiceTest {
@@ -54,149 +49,155 @@ public class OrderServiceTest extends ServiceTest {
 	private OrderWriter orderWriter;
 	@Mock
 	private OrderReader orderReader;
+	@Mock
+	private CartWriter cartWriter;
+	@Mock
+	private SaleReader saleReader;
 
 	@InjectMocks
 	private OrderService orderService;
 
-	@Nested
-	@DisplayName("주문 등록")
-	class postOrder {
-		private Long receiptId = ReceiptInfoFixture.NON_ADJUSTMENT_RECEIPT_INFO().getReceiptId();
-		private UserPassport userPassport = UserFixture.GENERAL_USER_PASSPORT();
-		private List<OrderMenu> orderMenus = List.of(OrderMenuFixture.GENERAL_ORDER_MENU());
-
-		@Test
-		void 회원_주문_등록_성공() {
-			주문_등록_성공_공통_로직(userPassport);
-			verify(receiptCustomerWriter).postReceiptCustomer(userPassport.getUserId(), receiptId);
-		}
-
-		@Test
-		void 점주_주문_등록_성공() {
-			UserPassport userPassport = UserFixture.OWNER_USER_PASSPORT();
-			BDDMockito.given(receiptValidator.isStoreOwner(any(), any()))
-				.willReturn(true);
-			주문_등록_성공_공통_로직(userPassport);
-			verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
-		}
-
-		@Test
-		void 비회원_주문_등록_성공() {
-			UserPassport userPassport = UserFixture.ANONYMOUS_USER_PASSPORT();
-			주문_등록_성공_공통_로직(userPassport);
-			verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
-		}
-
-		private void 주문_등록_성공_공통_로직(UserPassport userPassport) {
-			// given
-			Receipt receipt = ReceiptFixture.GENERAL_NON_ADJUSTMENT_RECEIPT();
-			List<Receipt> receipts = List.of(receipt);
-			List<Long> orderMenuIds = orderMenus.stream()
-				.map(orderMenu -> orderMenu.getMenu().getMenuInfo().getId())
-				.toList();
-
-			List<Long> receiptIds = List.of(receiptId);
-
-			BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
-				.willReturn(receipts);
-			BDDMockito.given(
-					menuReader.getMenuInfo(
-						BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
-						ArgumentMatchers.argThat(orderMenuIds::contains)))
-				.willReturn(Optional.of(MenuInfoFixture.GENERAL_MENU_INFO()));
-
-			// when
-			orderService.postOrder(receiptId, userPassport, orderMenus);
-
-			// then
-			verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
-			verify(saleValidator).validateSaleOpen(receipt.getSale());
-			verify(menuReader).getMenuInfo(
-				BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
-				ArgumentMatchers.argThat(orderMenuIds::contains));
-			verify(orderWriter).postOrder(receiptId, orderMenus);
-		}
-
-		@Test
-		void 영수증_조회_실패() {
-			// given
-			List<Long> receiptIds = List.of(receiptId);
-
-			BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
-				.willReturn(new ArrayList<>());
-
-			// when -> then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(() -> orderService.postOrder(receiptId, userPassport, orderMenus))
-					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.RECEIPT_NOT_FOUND);
-
-				verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
-				verify(saleValidator, never()).validateSaleOpen(any());
-				verify(menuReader, never()).getMenuInfo(anyLong(), any());
-				verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
-				verify(orderWriter, never()).postOrder(receiptId, orderMenus);
-			});
-		}
-
-		@Test
-		void 영업_종료로_인한_주문_실패() {
-			// given
-			List<Long> receiptIds = List.of(receiptId);
-			Receipt receipt = ReceiptFixture.GENERAL_CLOSE_SALE_NON_ADJSTMENT_RECEIPT();
-			List<Receipt> receipts = List.of(receipt);
-
-			BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
-				.willReturn(receipts);
-			doThrow(new ServiceException(ErrorCode.CLOSE_SALE))
-				.when(saleValidator).validateSaleOpen(receipt.getSale());
-
-			// when -> then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(() -> orderService.postOrder(receiptId, userPassport, orderMenus))
-					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLOSE_SALE);
-
-				verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
-				verify(saleValidator).validateSaleOpen(receipt.getSale());
-				verify(menuReader, never()).getMenuInfo(anyLong(), any());
-				verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
-				verify(orderWriter, never()).postOrder(receiptId, orderMenus);
-			});
-		}
-
-		@Test
-		void 메뉴_조회_실패() {
-			// given
-			List<Long> receiptIds = List.of(receiptId);
-			Receipt receipt = ReceiptFixture.GENERAL_CLOSE_SALE_NON_ADJSTMENT_RECEIPT();
-			List<Receipt> receipts = List.of(receipt);
-			List<Long> orderMenuIds = orderMenus.stream()
-				.map(orderMenu -> orderMenu.getMenu().getMenuInfo().getId())
-				.toList();
-
-			BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
-				.willReturn(receipts);
-			BDDMockito.given(
-					menuReader.getMenuInfo(
-						BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
-						ArgumentMatchers.argThat(orderMenuIds::contains)))
-				.willReturn(Optional.empty());
-
-			// when -> then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(() -> orderService.postOrder(receiptId, userPassport, orderMenus))
-					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_FOUND);
-
-				verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
-				verify(saleValidator).validateSaleOpen(receipt.getSale());
-				verify(menuReader).getMenuInfo(anyLong(), any());
-				verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
-				verify(orderWriter, never()).postOrder(receiptId, orderMenus);
-			});
-		}
-	}
+	// @Nested
+	// @DisplayName("장바구니를 사용하지 않는 주문 등록")
+	// @Deprecated
+	// class postOrderWithoutCart {
+	// 	private Long receiptId = ReceiptInfoFixture.NON_ADJUSTMENT_RECEIPT_INFO().getReceiptId();
+	// 	private UserPassport userPassport = UserFixture.GENERAL_USER_PASSPORT();
+	// 	private List<OrderMenu> orderMenus = List.of(OrderMenuFixture.GENERAL_ORDER_MENU());
+	//
+	// 	@Test
+	// 	void 회원_주문_등록_성공() {
+	// 		주문_등록_성공_공통_로직(userPassport);
+	// 		verify(receiptCustomerWriter).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 	}
+	//
+	// 	@Test
+	// 	void 점주_주문_등록_성공() {
+	// 		UserPassport userPassport = UserFixture.OWNER_USER_PASSPORT();
+	// 		BDDMockito.given(receiptValidator.isStoreOwner(any(), any()))
+	// 			.willReturn(true);
+	// 		주문_등록_성공_공통_로직(userPassport);
+	// 		verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 	}
+	//
+	// 	@Test
+	// 	void 비회원_주문_등록_성공() {
+	// 		UserPassport userPassport = UserFixture.ANONYMOUS_USER_PASSPORT();
+	// 		주문_등록_성공_공통_로직(userPassport);
+	// 		verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 	}
+	//
+	// 	private void 주문_등록_성공_공통_로직(UserPassport userPassport) {
+	// 		// given
+	// 		Receipt receipt = ReceiptFixture.GENERAL_NON_ADJUSTMENT_RECEIPT();
+	// 		List<Receipt> receipts = List.of(receipt);
+	// 		List<Long> orderMenuIds = orderMenus.stream()
+	// 			.map(orderMenu -> orderMenu.getMenu().getMenuInfo().getId())
+	// 			.toList();
+	//
+	// 		List<Long> receiptIds = List.of(receiptId);
+	//
+	//
+	// 		BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
+	// 			.willReturn(receipts);
+	// 		BDDMockito.given(
+	// 				menuReader.getMenuInfo(
+	// 					BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
+	// 					ArgumentMatchers.argThat(orderMenuIds::contains)))
+	// 			.willReturn(Optional.of(MenuInfoFixture.GENERAL_MENU_INFO()));
+	//
+	// 		// when
+	// 		orderService.postOrderWithoutCart(receiptId, userPassport, orderMenus);
+	//
+	// 		// then
+	// 		verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
+	// 		verify(saleValidator).validateSaleOpen(receipt.getSale());
+	// 		verify(menuReader).getMenuInfo(
+	// 			BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
+	// 			ArgumentMatchers.argThat(orderMenuIds::contains));
+	// 		verify(orderWriter).postOrderWithoutCart(receiptId, orderMenus);
+	// 	}
+	//
+	// 	@Test
+	// 	void 영수증_조회_실패() {
+	// 		// given
+	// 		List<Long> receiptIds = List.of(receiptId);
+	//
+	// 		BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
+	// 			.willReturn(new ArrayList<>());
+	//
+	// 		// when -> then
+	// 		assertSoftly(softly -> {
+	// 			softly.assertThatThrownBy(() -> orderService.postOrderWithoutCart(receiptId, userPassport, orderMenus))
+	// 				.isInstanceOf(ServiceException.class)
+	// 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.RECEIPT_NOT_FOUND);
+	//
+	// 			verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
+	// 			verify(saleValidator, never()).validateSaleOpen(any());
+	// 			verify(menuReader, never()).getMenuInfo(anyLong(), any());
+	// 			verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 			verify(orderWriter, never()).postOrderWithoutCart(receiptId, orderMenus);
+	// 		});
+	// 	}
+	//
+	// 	@Test
+	// 	void 영업_종료로_인한_주문_실패() {
+	// 		// given
+	// 		List<Long> receiptIds = List.of(receiptId);
+	// 		Receipt receipt = ReceiptFixture.GENERAL_CLOSE_SALE_NON_ADJSTMENT_RECEIPT();
+	// 		List<Receipt> receipts = List.of(receipt);
+	//
+	// 		BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
+	// 			.willReturn(receipts);
+	// 		doThrow(new ServiceException(ErrorCode.CLOSE_SALE))
+	// 			.when(saleValidator).validateSaleOpen(receipt.getSale());
+	//
+	// 		// when -> then
+	// 		assertSoftly(softly -> {
+	// 			softly.assertThatThrownBy(() -> orderService.postOrder(receiptId, userPassport, orderMenus))
+	// 				.isInstanceOf(ServiceException.class)
+	// 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.CLOSE_SALE);
+	//
+	// 			verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
+	// 			verify(saleValidator).validateSaleOpen(receipt.getSale());
+	// 			verify(menuReader, never()).getMenuInfo(anyLong(), any());
+	// 			verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 			verify(orderWriter, never()).postOrder(receiptId, orderMenus);
+	// 		});
+	// 	}
+	//
+	// 	@Test
+	// 	void 메뉴_조회_실패() {
+	// 		// given
+	// 		List<Long> receiptIds = List.of(receiptId);
+	// 		Receipt receipt = ReceiptFixture.GENERAL_CLOSE_SALE_NON_ADJSTMENT_RECEIPT();
+	// 		List<Receipt> receipts = List.of(receipt);
+	// 		List<Long> orderMenuIds = orderMenus.stream()
+	// 			.map(orderMenu -> orderMenu.getMenu().getMenuInfo().getId())
+	// 			.toList();
+	//
+	// 		BDDMockito.given(receiptReader.getNonStopReceiptsWithStoreAndLock(receiptIds))
+	// 			.willReturn(receipts);
+	// 		BDDMockito.given(
+	// 				menuReader.getMenuInfo(
+	// 					BDDMockito.eq(receipt.getSale().getStore().getStoreId()),
+	// 					ArgumentMatchers.argThat(orderMenuIds::contains)))
+	// 			.willReturn(Optional.empty());
+	//
+	// 		// when -> then
+	// 		assertSoftly(softly -> {
+	// 			softly.assertThatThrownBy(() -> orderService.postOrder(receiptId, userPassport, orderMenus))
+	// 				.isInstanceOf(ServiceException.class)
+	// 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_FOUND);
+	//
+	// 			verify(receiptReader).getNonStopReceiptsWithStoreAndLock(receiptIds);
+	// 			verify(saleValidator).validateSaleOpen(receipt.getSale());
+	// 			verify(menuReader).getMenuInfo(anyLong(), any());
+	// 			verify(receiptCustomerWriter, never()).postReceiptCustomer(userPassport.getUserId(), receiptId);
+	// 			verify(orderWriter, never()).postOrder(receiptId, orderMenus);
+	// 		});
+	// 	}
+	// }
 
 	@Nested
 	@DisplayName("주문 상태 변경")
@@ -250,14 +251,14 @@ public class OrderServiceTest extends ServiceTest {
 		@Test
 		void 영수증_별_주문_목록_조회_성공() {
 			// given
-			BDDMockito.given(orderReader.getReceiptOrders(receiptId))
+			BDDMockito.given(orderReader.getReceiptOrdersWithMenu(receiptId))
 				.willReturn(List.of(OrderFixture.GENERAL_ORDER()));
 			// when
 			orderService.getReceiptOrders(receiptId);
 
 			// then
 			verify(receiptValidator).validateReceipt(receiptId);
-			verify(orderReader).getReceiptOrders(receiptId);
+			verify(orderReader).getReceiptOrdersWithMenu(receiptId);
 		}
 
 		@Test
@@ -273,7 +274,7 @@ public class OrderServiceTest extends ServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.RECEIPT_NOT_FOUND);
 
 				verify(receiptValidator).validateReceipt(receiptId);
-				verify(orderReader, never()).getReceiptOrders(receiptId);
+				verify(orderReader, never()).getReceiptOrdersWithMenu(receiptId);
 			});
 		}
 	}
@@ -287,20 +288,20 @@ public class OrderServiceTest extends ServiceTest {
 		void 주문_상세_조회_성공() {
 			// given
 			Order order = OrderFixture.GENERAL_ORDER();
-			BDDMockito.given(orderReader.getOrder(orderId))
+			BDDMockito.given(orderReader.getOrderWithMenu(orderId))
 				.willReturn(Optional.of(order));
 
 			// when
 			orderService.getOrder(orderId);
 
 			// then
-			verify(orderReader).getOrder(orderId);
+			verify(orderReader).getOrderWithMenu(orderId);
 		}
 
 		@Test
 		void 주문_조회_실패() {
 			// given
-			BDDMockito.given(orderReader.getOrder(orderId))
+			BDDMockito.given(orderReader.getOrderWithMenu(orderId))
 				.willReturn(Optional.empty());
 
 			// when, then
@@ -309,7 +310,7 @@ public class OrderServiceTest extends ServiceTest {
 					.isInstanceOf(ServiceException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_NOT_FOUND);
 
-				verify(orderReader).getOrder(orderId);
+				verify(orderReader).getOrderWithMenu(orderId);
 			});
 		}
 	}

--- a/domain/domain-pos/src/testFixtures/java/fixtures/order/OrderFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/order/OrderFixture.java
@@ -48,7 +48,7 @@ public class OrderFixture {
 	public static Order CANCELLED_ORDER() {
 		return Order.builder()
 			.orderId(GENERAL_ORDER_ID)
-			.orderStatus(OrderStatus.CANCELLED)
+			.orderStatus(OrderStatus.CANCELED)
 			.totalPrice(GENERAL_TOTAL_PRICE)
 			.receipt(GENERAL_RECEIPT)
 			.orderMenus(GENERAL_ORDER_MENUS)

--- a/infra/rdb/pos/src/main/java/com/pos/menu/entity/MenuEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/entity/MenuEntity.java
@@ -6,9 +6,7 @@ import org.hibernate.annotations.SQLRestriction;
 import com.pos.global.base.entity.BaseEntity;
 import com.pos.store.entity.StoreEntity;
 
-import domain.pos.menu.entity.MenuCategoryInfo;
 import domain.pos.menu.entity.MenuInfo;
-import domain.pos.store.entity.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -86,7 +84,7 @@ public class MenuEntity extends BaseEntity {
 		this.id = menuId;
 	}
 
-	public static MenuEntity of(MenuInfo menuInfo, Store store, MenuCategoryInfo menuCategoryInfo) {
+	public static MenuEntity of(MenuInfo menuInfo, StoreEntity storeEntity, MenuCategoryEntity menuCategoryEntity) {
 		return MenuEntity.builder()
 			.order(menuInfo.getOrder())
 			.name(menuInfo.getName())
@@ -95,8 +93,8 @@ public class MenuEntity extends BaseEntity {
 			.imageUrl(menuInfo.getImageUrl())
 			.isSoldOut(menuInfo.isSoldOut())
 			.isRecommended(menuInfo.isRecommended())
-			.store(StoreEntity.from(store.getStoreId()))
-			.menuCategory(MenuCategoryEntity.from(menuCategoryInfo.getId()))
+			.store(storeEntity)
+			.menuCategory(menuCategoryEntity)
 			.build();
 	}
 

--- a/infra/rdb/pos/src/main/java/com/pos/menu/mapper/MenuMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/mapper/MenuMapper.java
@@ -1,6 +1,8 @@
 package com.pos.menu.mapper;
 
+import com.pos.menu.entity.MenuCategoryEntity;
 import com.pos.menu.entity.MenuEntity;
+import com.pos.store.mapper.StoreMapper;
 
 import domain.pos.menu.entity.Menu;
 import domain.pos.menu.entity.MenuCategory;
@@ -10,7 +12,8 @@ import domain.pos.store.entity.Store;
 
 public class MenuMapper {
 	public static MenuEntity toMenuEntity(MenuInfo menuInfo, Store store, MenuCategoryInfo menuCategoryInfo) {
-		return MenuEntity.of(menuInfo, store, menuCategoryInfo);
+		return MenuEntity.of(menuInfo, StoreMapper.toStoreEntity(store.getStoreId()),
+			MenuCategoryEntity.from(menuCategoryInfo.getId()));
 	}
 
 	public static Menu toMenu(MenuEntity menuEntity, Store store, MenuCategory menuCategory) {

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,12 +57,17 @@ public class MenuRepositoryImpl implements MenuRepository {
 	}
 
 	@Override
-	public Slice<MenuInfo> getMenuSlice(Pageable pageable, MenuInfo lastMenuInfo, Long menuCategoryId) {
+	public Slice<MenuInfo> getMenuSlice(int pageSize, MenuInfo lastMenuInfo, Long menuCategoryId) {
 		return menuJpaRepository.findSliceByMenuCategoryId(
-			pageable,
+			pageSize,
 			lastMenuInfo == null ? null : lastMenuInfo.getOrder(),
 			menuCategoryId
 		).map(MenuMapper::toMenuInfo);
+	}
+
+	@Override
+	public boolean existsMenu(Long storeId, Long menuId) {
+		return menuJpaRepository.existsByIdAndStoreId(menuId, storeId);
 	}
 
 	@Override
@@ -72,7 +76,7 @@ public class MenuRepositoryImpl implements MenuRepository {
 	}
 
 	@Override
-	public MenuInfo patchMenu(MenuInfo patchMenuInfo) {
+	public MenuInfo patchMenuInfo(MenuInfo patchMenuInfo) {
 		MenuEntity menuEntity = menuJpaRepository.findById(patchMenuInfo.getId()).get();
 		menuEntity.updateWithoutOrder(patchMenuInfo);
 		return MenuMapper.toMenuInfo(menuEntity);
@@ -110,6 +114,11 @@ public class MenuRepositoryImpl implements MenuRepository {
 		menuJpaRepository.delete(menuEntity);
 		menuJpaRepository.decreaseOrderWhereGT(menu.getMenuCategory().getMenuCategoryInfo().getId(),
 			periodOrder);
+	}
+
+	@Override
+	public Long countByIdIn(Long storeId, List<Long> menuIds) {
+		return menuJpaRepository.countByIdIn(storeId, menuIds);
 	}
 
 	@Override

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/impl/MenuRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.pos.menu.repository.impl;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
@@ -117,7 +118,7 @@ public class MenuRepositoryImpl implements MenuRepository {
 	}
 
 	@Override
-	public Long countByIdIn(Long storeId, List<Long> menuIds) {
+	public Long countByIdIn(Long storeId, Set<Long> menuIds) {
 		return menuJpaRepository.countByIdIn(storeId, menuIds);
 	}
 

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepository.java
@@ -3,7 +3,6 @@ package com.pos.menu.repository.querydsl;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.pos.menu.entity.MenuEntity;
@@ -13,7 +12,9 @@ public interface MenuQueryDslRepository {
 
 	List<MenuEntity> findAllByStoreIdWithCategoryAndLock(Long storeId);
 
-	Slice<MenuEntity> findSliceByMenuCategoryId(Pageable pageable, Integer lastMenuOrder, Long menuCategoryId);
+	Slice<MenuEntity> findSliceByMenuCategoryId(int pageSize, Integer lastMenuOrder, Long menuCategoryId);
+
+	boolean existsByIdAndStoreId(Long menuId, Long storeId);
 
 	boolean existsMenuOrder(Long menuCategoryId, int menuOrder);
 
@@ -22,5 +23,7 @@ public interface MenuQueryDslRepository {
 	void increaseOrderInRange(Long menuCategoryId, Integer startOrder, Integer endOrder);
 
 	void decreaseOrderWhereGT(Long menuCategoryId, Integer deleteOrder);
+
+	Long countByIdIn(Long storeId, List<Long> menuIds);
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.pos.menu.repository.querydsl;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Slice;
 
@@ -24,6 +25,6 @@ public interface MenuQueryDslRepository {
 
 	void decreaseOrderWhereGT(Long menuCategoryId, Integer deleteOrder);
 
-	Long countByIdIn(Long storeId, List<Long> menuIds);
+	Long countByIdIn(Long storeId, Set<Long> menuIds);
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/repository/querydsl/MenuQueryDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.pos.menu.repository.querydsl;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -114,7 +115,7 @@ public class MenuQueryDslRepositoryImpl implements MenuQueryDslRepository {
 	}
 
 	@Override
-	public Long countByIdIn(Long storeId, List<Long> menuIds) {
+	public Long countByIdIn(Long storeId, Set<Long> menuIds) {
 		return jpaQueryFactory
 			.select(qMenuEntity.count())
 			.from(qMenuEntity)

--- a/infra/rdb/pos/src/main/java/com/pos/order/entity/OrderEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/entity/OrderEntity.java
@@ -1,10 +1,12 @@
 package com.pos.order.entity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import com.pos.global.base.entity.BaseEntity;
 import com.pos.receipt.entity.ReceiptEntity;
 
 import domain.pos.order.entity.vo.OrderStatus;
@@ -21,6 +23,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,7 +33,7 @@ import lombok.NoArgsConstructor;
 @SQLDelete(sql = "UPDATE orders SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 @Getter
-public class OrderEntity {
+public class OrderEntity extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -38,7 +41,7 @@ public class OrderEntity {
 	@Enumerated(value = EnumType.STRING)
 	private OrderStatus status;
 
-	@Column(name = "table_price", nullable = false)
+	@Column(name = "table_price")
 	private Integer totalPrice;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -46,14 +49,13 @@ public class OrderEntity {
 	private ReceiptEntity receipt;
 
 	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<OrderMenuEntity> orderMenus;
+	private List<OrderMenuEntity> orderMenus = new ArrayList<>();
 
-	public OrderEntity(OrderStatus status, Integer totalPrice, ReceiptEntity receipt,
-		List<OrderMenuEntity> orderMenus) {
+	@Builder
+	public OrderEntity(OrderStatus status, Integer totalPrice, ReceiptEntity receipt) {
 		this.status = status;
 		this.totalPrice = totalPrice;
 		this.receipt = receipt;
-		this.orderMenus = orderMenus;
 	}
 
 	public OrderEntity(Long id) {
@@ -62,5 +64,9 @@ public class OrderEntity {
 
 	public static OrderEntity from(Long id) {
 		return new OrderEntity(id);
+	}
+
+	public void setOrderStatus(OrderStatus orderStatus) {
+		this.status = orderStatus;
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/order/entity/OrderMenuEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/entity/OrderMenuEntity.java
@@ -3,11 +3,14 @@ package com.pos.order.entity;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import com.pos.global.base.entity.BaseEntity;
 import com.pos.menu.entity.MenuEntity;
 
-import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +26,7 @@ import lombok.NoArgsConstructor;
 @SQLDelete(sql = "UPDATE order_menus SET deleted_at = NOW() where id=?")
 @SQLRestriction(value = "deleted_at is NULL")
 @Getter
-public class OrderMenuEntity {
+public class OrderMenuEntity extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +35,8 @@ public class OrderMenuEntity {
 	@Column(name = "quntity", nullable = false)
 	private Integer quantity;
 
-	// TODO : 메뉴 상태?
+	@Enumerated(value = EnumType.STRING)
+	private OrderMenuStatus status;
 
 	@ManyToOne
 	@JoinColumn(name = "order_id", nullable = false)
@@ -42,17 +46,15 @@ public class OrderMenuEntity {
 	@JoinColumn(name = "menu_id", nullable = false)
 	private MenuEntity menu;
 
-	private OrderMenuEntity(Integer quantity, OrderEntity order, MenuEntity menu) {
+	private OrderMenuEntity(Integer quantity, OrderMenuStatus status, OrderEntity order, MenuEntity menu) {
 		this.quantity = quantity;
+		this.status = status;
 		this.order = order;
 		this.menu = menu;
 	}
 
-	public static OrderMenuEntity of(OrderMenu orderMenu) {
-		return new OrderMenuEntity(
-			orderMenu.getQuantity(),
-			OrderEntity.from(orderMenu.getOrder().getOrderId()),
-			MenuEntity.from(orderMenu.getOrderMenuId()));
+	public static OrderMenuEntity of(Integer quantity, OrderMenuStatus status, OrderEntity order, MenuEntity menu) {
+		return new OrderMenuEntity(quantity, status, order, menu);
 	}
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/order/mapper/OrderMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/mapper/OrderMapper.java
@@ -3,12 +3,22 @@ package com.pos.order.mapper;
 import java.util.List;
 
 import com.pos.order.entity.OrderEntity;
+import com.pos.receipt.entity.ReceiptEntity;
 
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderStatus;
 import domain.pos.receipt.entity.Receipt;
 
 public class OrderMapper {
+	public static OrderEntity toOrderEntity(OrderStatus orderStatus, Integer totalPrice, Receipt receipt) {
+		return OrderEntity.builder()
+			.status(orderStatus)
+			.totalPrice(totalPrice)
+			.receipt(ReceiptEntity.from(receipt.getReceiptInfo().getReceiptId()))
+			.build();
+	}
+
 	public static Order toOrder(OrderEntity orderEntity, Receipt receipt, List<OrderMenu> orderMenus) {
 		return Order.builder()
 			.orderId(orderEntity.getId())

--- a/infra/rdb/pos/src/main/java/com/pos/order/mapper/OrderMenuMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/mapper/OrderMenuMapper.java
@@ -1,23 +1,43 @@
 package com.pos.order.mapper;
 
+import com.pos.menu.entity.MenuEntity;
+import com.pos.order.entity.OrderEntity;
 import com.pos.order.entity.OrderMenuEntity;
 
+import domain.pos.cart.entity.CartMenu;
 import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuInfo;
 import domain.pos.order.entity.Order;
 import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
 
 public class OrderMenuMapper {
-
 	public static OrderMenu toOrderMenu(OrderMenuEntity orderMenuEntity, Order order, Menu menu) {
 		return OrderMenu.builder()
 			.orderMenuId(orderMenuEntity.getId())
+			.orderMenuStatus(orderMenuEntity.getStatus())
 			.quantity(orderMenuEntity.getQuantity())
 			.order(order)
 			.menu(menu)
 			.build();
 	}
 
-	public static OrderMenuEntity toOrderMenuEntity(OrderMenu orderMenu) {
-		return OrderMenuEntity.of(orderMenu);
+	public static OrderMenuEntity toOrderMenuEntity(MenuInfo menuInfo, Integer quantity,
+		OrderMenuStatus orderMenuStatus, Order order) {
+		return OrderMenuEntity.of(
+			quantity,
+			orderMenuStatus,
+			OrderEntity.from(order.getOrderId()),
+			MenuEntity.from(menuInfo.getId()));
+	}
+
+	public static OrderMenuEntity toOrderMenuEntity(CartMenu cartMenu, OrderMenuStatus status, OrderEntity orderEntity,
+		MenuEntity menuEntity) {
+		return OrderMenuEntity.of(
+			cartMenu.getQuantity(),
+			status,
+			orderEntity,
+			menuEntity
+		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderMenuRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderMenuRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.pos.order.repository.impl;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pos.menu.mapper.MenuMapper;
+import com.pos.order.entity.OrderMenuEntity;
+import com.pos.order.mapper.OrderMapper;
+import com.pos.order.mapper.OrderMenuMapper;
+import com.pos.order.repository.jpa.OrderJpaRepository;
+import com.pos.order.repository.jpa.OrderMenuJpaRepository;
+import com.pos.store.mapper.StoreMapper;
+
+import domain.pos.menu.entity.Menu;
+import domain.pos.menu.entity.MenuInfo;
+import domain.pos.order.entity.Order;
+import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderMenuStatus;
+import domain.pos.order.repository.OrderMenuRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderMenuRepositoryImpl implements OrderMenuRepository {
+	private final OrderMenuJpaRepository orderMenuJpaRepository;
+	private final OrderJpaRepository orderJpaRepository;
+
+	@Override
+	@Transactional
+	public OrderMenu postOrderMenu(MenuInfo menuInfo, Integer quantity, Order order) {
+		OrderMenuEntity orderMenuEntity = OrderMenuMapper.toOrderMenuEntity(menuInfo, quantity, OrderMenuStatus.COOKING,
+			order);
+		orderJpaRepository.plusOrderPrice(order.getOrderId(), menuInfo.getPrice() * quantity);
+		return OrderMenuMapper.toOrderMenu(orderMenuJpaRepository.save(orderMenuEntity), order,
+			Menu.of(menuInfo, null, null));
+	}
+
+	@Override
+	public Optional<OrderMenu> getOrderMenuWithOrderAndStore(Long orderMenuId) {
+		return orderMenuJpaRepository.findByIdWithOrderAndStore(orderMenuId)
+			.map(orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity,
+				OrderMapper.toOrder(orderMenuEntity.getOrder(), null, null),
+				MenuMapper.toMenu(orderMenuEntity.getMenu(),
+					StoreMapper.toStore(orderMenuEntity.getMenu().getStore()), null)));
+	}
+
+	@Override
+	@Transactional
+	public void deleteOrderMenu(OrderMenu orderMenu) {
+		orderJpaRepository.subtractOrderPrice(orderMenu.getOrder().getOrderId(),
+			orderMenu.getMenu().getMenuInfo().getPrice() * orderMenu.getQuantity());
+		orderMenuJpaRepository.deleteById(orderMenu.getOrderMenuId());
+	}
+
+	@Override
+	@Transactional
+	public OrderMenu patchOrderMenuStatus(OrderMenu orderMenu, OrderMenuStatus orderMenuStatus) {
+		if (orderMenuStatus == OrderMenuStatus.CANCELED) {
+			int menuPrice = orderMenu.getMenu().getMenuInfo().getPrice() * orderMenu.getQuantity();
+			orderJpaRepository.subtractOrderPrice(orderMenu.getOrder().getOrderId(), menuPrice);
+		} else if (orderMenuStatus == OrderMenuStatus.COOKING) {
+			int menuPrice = orderMenu.getMenu().getMenuInfo().getPrice() * orderMenu.getQuantity();
+			orderJpaRepository.plusOrderPrice(orderMenu.getOrder().getOrderId(), menuPrice);
+		}
+
+		orderMenuJpaRepository.updateOrderMenuStatus(orderMenu.getOrderMenuId(), orderMenuStatus);
+		orderMenu.setOrderMenuStatus(orderMenuStatus);
+		return orderMenu;
+	}
+
+	@Override
+	public boolean existsCookingMenu(Long orderId) {
+		return orderMenuJpaRepository.existsCookingMenu(orderId);
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderRepositoryImpl.java
@@ -1,0 +1,157 @@
+package com.pos.order.repository.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pos.menu.mapper.MenuMapper;
+import com.pos.order.entity.OrderEntity;
+import com.pos.order.entity.OrderMenuEntity;
+import com.pos.order.mapper.OrderMapper;
+import com.pos.order.mapper.OrderMenuMapper;
+import com.pos.order.repository.jpa.OrderJpaRepository;
+import com.pos.order.repository.jpa.OrderMenuJpaRepository;
+import com.pos.receipt.mapper.ReceiptMapper;
+import com.pos.receipt.repository.jpa.ReceiptJpaRepository;
+import com.pos.sale.mapper.SaleMapper;
+import com.pos.store.mapper.StoreMapper;
+
+import domain.pos.cart.entity.CartMenu;
+import domain.pos.order.entity.Order;
+import domain.pos.order.entity.OrderMenu;
+import domain.pos.order.entity.vo.OrderStatus;
+import domain.pos.order.repository.OrderRepository;
+import domain.pos.receipt.entity.Receipt;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+	private final OrderJpaRepository orderJpaRepository;
+	private final OrderMenuJpaRepository orderMenuJpaRepository;
+	private final ReceiptJpaRepository receiptJpaRepository;
+
+	@Override
+	@Transactional
+	public Order postOrderWithCart(Receipt receipt, List<CartMenu> cartMenus) {
+		// 최초 주문 시 영수증 시작시간 기록
+		if (!orderJpaRepository.existsOrderByReceiptId(receipt.getReceiptInfo().getReceiptId())) {
+			receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+		}
+
+		// 주문 총 금액 계산
+		int totalPrice = cartMenus.stream()
+			.mapToInt(cartMenu -> cartMenu.getMenuInfo().getPrice() * cartMenu.getQuantity())
+			.sum();
+		OrderEntity orderEntity = OrderMapper.toOrderEntity(OrderStatus.ORDERED, totalPrice, receipt);
+
+		// CartMenu -> OrderMenuEntity 변환
+		List<OrderMenuEntity> orderMenuEntities = cartMenus.stream()
+			.map(cartMenu -> OrderMenuMapper.toOrderMenuEntity(
+				cartMenu,
+				orderEntity.getStatus().transferOrderMenuStatus(),
+				orderEntity,
+				MenuMapper.toMenuEntity(cartMenu.getMenuInfo(), null, null)))
+			.toList();
+		orderEntity.getOrderMenus().addAll(orderMenuEntities);
+
+		OrderEntity savedOrderEntity = orderJpaRepository.save(orderEntity);
+
+		List<OrderMenu> savedOrderMenus = savedOrderEntity.getOrderMenus().stream()
+			.map(orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity, null,
+				MenuMapper.toMenu(orderMenuEntity.getMenu(), null, null)))
+			.toList();
+		return OrderMapper.toOrder(
+			savedOrderEntity,
+			receipt,
+			savedOrderMenus);
+	}
+
+	@Override
+	@Transactional
+	public Order postOrderWithoutCart(Receipt receipt, List<OrderMenu> orderMenus) {
+		// 최초 주문 시 영수증 시작시간 기록
+		if (!orderJpaRepository.existsOrderByReceiptId(receipt.getReceiptInfo().getReceiptId())) {
+			receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+		}
+
+		// 주문 총 금액 계산
+		int totalPrice = orderMenus.stream()
+			.mapToInt(orderMenu -> orderMenu.getMenu().getMenuInfo().getPrice() * orderMenu.getQuantity())
+			.sum();
+		OrderEntity orderEntity = OrderMapper.toOrderEntity(OrderStatus.ORDERED, totalPrice, receipt);
+
+		// orderMenu -> OrderMenuEntity 변환
+		List<OrderMenuEntity> orderMenuEntities = orderMenus.stream()
+			.map(orderMenu -> OrderMenuMapper.toOrderMenuEntity(
+				orderMenu.getMenu().getMenuInfo(),
+				orderMenu.getQuantity(),
+				orderEntity.getStatus().transferOrderMenuStatus(),
+				OrderMapper.toOrder(orderEntity, null, null)))
+			.toList();
+		orderEntity.getOrderMenus().addAll(orderMenuEntities);
+
+		OrderEntity savedOrderEntity = orderJpaRepository.save(orderEntity);
+
+		List<OrderMenu> savedOrderMenus = savedOrderEntity.getOrderMenus().stream()
+			.map(orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity, null,
+				MenuMapper.toMenu(orderMenuEntity.getMenu(), null, null)))
+			.toList();
+		return OrderMapper.toOrder(
+			savedOrderEntity,
+			receipt,
+			savedOrderMenus);
+	}
+
+	@Override
+	public Optional<Order> getOrderWithMenu(Long orderId) {
+		return orderJpaRepository.findByIdWithMenus(orderId)
+			.map(orderEntity -> OrderMapper.toOrder(orderEntity, null, orderEntity.getOrderMenus().stream().map(
+				orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity, null,
+					MenuMapper.toMenu(orderMenuEntity.getMenu(), null, null))).toList()));
+	}
+
+	@Override
+	public Optional<Order> getOrderWithStore(Long orderId) {
+		return orderJpaRepository.findByIdWithStore(orderId)
+			.map(orderEntity -> OrderMapper.toOrder(orderEntity, ReceiptMapper.toReceipt(orderEntity.getReceipt(), null,
+					SaleMapper.toSale(orderEntity.getReceipt().getSale(),
+						StoreMapper.toStore(orderEntity.getReceipt().getSale().getStore()))),
+				null));
+	}
+
+	@Override
+	@Transactional
+	public Order patchOrderStatus(Order order, OrderStatus orderStatus) {
+		orderJpaRepository.updateOrderStatus(order.getOrderId(), orderStatus);
+		orderMenuJpaRepository.updateOrderMenuStatus(order.getOrderId(), orderStatus.transferOrderMenuStatus());
+		order.setOrderStatus(orderStatus);
+		return order;
+	}
+
+	@Override
+	public List<Order> getSaleOrdersWithMenuAndTable(Long saleId, List<OrderStatus> orderStatuses) {
+		return orderJpaRepository.findSaleOrdersWithMenuAndTable(saleId, orderStatuses)
+			.stream()
+			.map(orderEntity -> OrderMapper.toOrder(orderEntity, null,
+				orderEntity.getOrderMenus().stream()
+					.map(orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity, null,
+						MenuMapper.toMenu(orderMenuEntity.getMenu(), null, null)))
+					.toList()))
+			.toList();
+	}
+
+	@Override
+	public List<Order> getReceiptOrdersWithMenu(Long receiptId) {
+		return orderJpaRepository.findReceiptOrdersWithMenu(receiptId)
+			.stream()
+			.map(orderEntity -> OrderMapper.toOrder(orderEntity, null,
+				orderEntity.getOrderMenus().stream()
+					.map(orderMenuEntity -> OrderMenuMapper.toOrderMenu(orderMenuEntity, null,
+						MenuMapper.toMenu(orderMenuEntity.getMenu(), null, null)))
+					.toList()))
+			.toList();
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/jpa/OrderMenuJpaRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/jpa/OrderMenuJpaRepository.java
@@ -1,0 +1,9 @@
+package com.pos.order.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.pos.order.entity.OrderMenuEntity;
+import com.pos.order.repository.querydsl.OrderMenuQueryDslRepository;
+
+public interface OrderMenuJpaRepository extends JpaRepository<OrderMenuEntity, Long>, OrderMenuQueryDslRepository {
+}

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderMenuQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderMenuQueryDslRepository.java
@@ -1,0 +1,15 @@
+package com.pos.order.repository.querydsl;
+
+import java.util.Optional;
+
+import com.pos.order.entity.OrderMenuEntity;
+
+import domain.pos.order.entity.vo.OrderMenuStatus;
+
+public interface OrderMenuQueryDslRepository {
+	Optional<OrderMenuEntity> findByIdWithOrderAndStore(Long orderMenuId);
+
+	void updateOrderMenuStatus(Long orderId, OrderMenuStatus orderStatus);
+
+	boolean existsCookingMenu(Long orderId);
+}

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderMenuQueryDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderMenuQueryDslRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.pos.order.repository.querydsl;
+
+import java.util.Optional;
+
+import com.pos.order.entity.OrderMenuEntity;
+import com.pos.order.entity.QOrderMenuEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import domain.pos.order.entity.vo.OrderMenuStatus;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderMenuQueryDslRepositoryImpl implements OrderMenuQueryDslRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+	private final QOrderMenuEntity qOrderMenuEntity = QOrderMenuEntity.orderMenuEntity;
+
+	@Override
+	public Optional<OrderMenuEntity> findByIdWithOrderAndStore(Long orderMenuId) {
+		OrderMenuEntity orderMenuEntity = jpaQueryFactory
+			.selectFrom(qOrderMenuEntity)
+			.join(qOrderMenuEntity.order).fetchJoin()
+			.join(qOrderMenuEntity.menu).fetchJoin()
+			.join(qOrderMenuEntity.menu.store).fetchJoin()
+			.where(qOrderMenuEntity.id.eq(orderMenuId))
+			.fetchOne();
+		return Optional.ofNullable(orderMenuEntity);
+	}
+
+	@Override
+	public void updateOrderMenuStatus(Long orderId, OrderMenuStatus orderStatus) {
+		jpaQueryFactory.update(qOrderMenuEntity)
+			.set(qOrderMenuEntity.status, orderStatus)
+			.where(qOrderMenuEntity.order.id.eq(orderId))
+			.execute();
+	}
+
+	@Override
+	public boolean existsCookingMenu(Long orderId) {
+		return jpaQueryFactory
+			.selectOne()
+			.from(qOrderMenuEntity)
+			.where(qOrderMenuEntity.order.id.eq(orderId)
+				.and(qOrderMenuEntity.status.in(OrderMenuStatus.ORDERED, OrderMenuStatus.COOKING)))
+			.fetchFirst() != null;
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepository.java
@@ -1,4 +1,27 @@
 package com.pos.order.repository.querydsl;
 
+import java.util.List;
+import java.util.Optional;
+
+import com.pos.order.entity.OrderEntity;
+
+import domain.pos.order.entity.vo.OrderStatus;
+
 public interface OrderQueryDslRepository {
+	Optional<OrderEntity> findByIdWithMenus(Long orderId);
+
+	Optional<OrderEntity> findByIdWithStore(Long orderId);
+
+	List<OrderEntity> findSaleOrdersWithMenuAndTable(Long saleId, List<OrderStatus> orderStatuses);
+
+	List<OrderEntity> findReceiptOrdersWithMenu(Long receiptId);
+
+	boolean existsOrderByReceiptId(Long receiptId);
+
+	void updateOrderStatus(Long orderId, OrderStatus orderStatus);
+
+	void subtractOrderPrice(Long orderId, Integer menuPrice);
+
+	void plusOrderPrice(Long orderId, Integer menuPrice);
+
 }

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepositoryImpl.java
@@ -21,7 +21,7 @@ public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
 		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
 
 		OrderEntity orderEntity = jpaQueryFactory
-			.selectFrom(qOrderEntity)
+			.selectFrom(qOrderEntity).distinct()
 			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
 			.join(qOrderMenu.menu).fetchJoin()
 			.where(qOrderEntity.id.eq(orderId))
@@ -48,7 +48,7 @@ public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
 		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
 
 		return jpaQueryFactory
-			.selectFrom(qOrderEntity)
+			.selectFrom(qOrderEntity).distinct()
 			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
 			.join(qOrderMenu.menu).fetchJoin()
 			.join(qOrderEntity.receipt).fetchJoin()
@@ -63,7 +63,7 @@ public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
 		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
 
 		return jpaQueryFactory
-			.selectFrom(qOrderEntity)
+			.selectFrom(qOrderEntity).distinct()
 			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
 			.join(qOrderMenu.menu).fetchJoin()
 			.where(qOrderEntity.receipt.id.eq(receiptId))

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/querydsl/OrderQueryDslRepositoryImpl.java
@@ -1,5 +1,106 @@
 package com.pos.order.repository.querydsl;
 
-public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
+import java.util.List;
+import java.util.Optional;
 
+import com.pos.order.entity.OrderEntity;
+import com.pos.order.entity.QOrderEntity;
+import com.pos.order.entity.QOrderMenuEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import domain.pos.order.entity.vo.OrderStatus;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderQueryDslRepositoryImpl implements OrderQueryDslRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+	private final QOrderEntity qOrderEntity = QOrderEntity.orderEntity;
+
+	@Override
+	public Optional<OrderEntity> findByIdWithMenus(Long orderId) {
+		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
+
+		OrderEntity orderEntity = jpaQueryFactory
+			.selectFrom(qOrderEntity)
+			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
+			.join(qOrderMenu.menu).fetchJoin()
+			.where(qOrderEntity.id.eq(orderId))
+			.fetchOne();
+
+		return Optional.ofNullable(orderEntity);
+	}
+
+	@Override
+	public Optional<OrderEntity> findByIdWithStore(Long orderId) {
+		OrderEntity orderEntity = jpaQueryFactory
+			.selectFrom(qOrderEntity)
+			.join(qOrderEntity.receipt).fetchJoin()
+			.join(qOrderEntity.receipt.sale).fetchJoin()
+			.join(qOrderEntity.receipt.sale.store).fetchJoin()
+			.where(qOrderEntity.id.eq(orderId))
+			.fetchOne();
+
+		return Optional.ofNullable(orderEntity);
+	}
+
+	@Override
+	public List<OrderEntity> findSaleOrdersWithMenuAndTable(Long saleId, List<OrderStatus> orderStatuses) {
+		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
+
+		return jpaQueryFactory
+			.selectFrom(qOrderEntity)
+			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
+			.join(qOrderMenu.menu).fetchJoin()
+			.join(qOrderEntity.receipt).fetchJoin()
+			.join(qOrderEntity.receipt.table).fetchJoin()
+			.where(qOrderEntity.receipt.sale.id.eq(saleId)
+				.and(qOrderEntity.status.in(orderStatuses)))
+			.fetch();
+	}
+
+	@Override
+	public List<OrderEntity> findReceiptOrdersWithMenu(Long receiptId) {
+		QOrderMenuEntity qOrderMenu = QOrderMenuEntity.orderMenuEntity;
+
+		return jpaQueryFactory
+			.selectFrom(qOrderEntity)
+			.join(qOrderEntity.orderMenus, qOrderMenu).fetchJoin()
+			.join(qOrderMenu.menu).fetchJoin()
+			.where(qOrderEntity.receipt.id.eq(receiptId))
+			.fetch();
+	}
+
+	@Override
+	public boolean existsOrderByReceiptId(Long receiptId) {
+		return jpaQueryFactory
+			.selectOne()
+			.from(qOrderEntity)
+			.where(qOrderEntity.receipt.id.eq(receiptId))
+			.fetchFirst() != null;
+	}
+
+	@Override
+	public void updateOrderStatus(Long orderId, OrderStatus orderStatus) {
+		jpaQueryFactory
+			.update(qOrderEntity)
+			.set(qOrderEntity.status, orderStatus)
+			.where(qOrderEntity.id.eq(orderId))
+			.execute();
+	}
+
+	@Override
+	public void subtractOrderPrice(Long orderId, Integer menuPrice) {
+		jpaQueryFactory.update(qOrderEntity)
+			.set(qOrderEntity.totalPrice, qOrderEntity.totalPrice.subtract(menuPrice))
+			.where(qOrderEntity.id.eq(orderId))
+			.execute();
+	}
+
+	@Override
+	public void plusOrderPrice(Long orderId, Integer menuPrice) {
+		jpaQueryFactory.update(qOrderEntity)
+			.set(qOrderEntity.totalPrice, qOrderEntity.totalPrice.add(menuPrice))
+			.where(qOrderEntity.id.eq(orderId))
+			.execute();
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/entity/ReceiptEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/entity/ReceiptEntity.java
@@ -13,7 +13,6 @@ import com.pos.sale.entity.SaleEntity;
 import com.pos.table.entity.TableEntity;
 
 import domain.pos.receipt.entity.ReceiptInfo;
-import domain.pos.store.entity.Sale;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -78,9 +77,10 @@ public class ReceiptEntity extends BaseEntity {
 	}
 
 	public static ReceiptEntity of(
-		Sale sale, domain.pos.table.entity.Table table) {
+		SaleEntity saleEntity, TableEntity tableEntity) {
 		return ReceiptEntity.builder()
-			.sale(SaleEntity.from(sale.getSaleId()))
+			.sale(saleEntity)
+			.table(tableEntity)
 			.build();
 	}
 

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/mapper/ReceiptMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/mapper/ReceiptMapper.java
@@ -6,6 +6,8 @@ import com.pos.menu.mapper.MenuMapper;
 import com.pos.order.mapper.OrderMapper;
 import com.pos.order.mapper.OrderMenuMapper;
 import com.pos.receipt.entity.ReceiptEntity;
+import com.pos.sale.entity.SaleEntity;
+import com.pos.table.entity.TableEntity;
 
 import domain.pos.order.entity.Order;
 import domain.pos.receipt.entity.Receipt;
@@ -16,7 +18,7 @@ import domain.pos.table.entity.Table;
 public class ReceiptMapper {
 
 	public static ReceiptEntity toReceiptEntity(Sale sale, Table table) {
-		return ReceiptEntity.of(sale, table);
+		return ReceiptEntity.of(SaleEntity.from(sale.getSaleId()), TableEntity.from(table.getTableId()));
 	}
 
 	public static Receipt toReceipt(ReceiptEntity receiptEntity, Table table, Sale sale) {

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/repository/impl/ReceiptRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/repository/impl/ReceiptRepositoryImpl.java
@@ -70,6 +70,14 @@ public class ReceiptRepositoryImpl implements ReceiptRepository {
 	}
 
 	@Override
+	public Optional<Receipt> getNonStopReceiptsWithTableAndStoreAndLock(Long receiptId) {
+		return receiptJpaRepository.findNonStopReceiptsByIdWithTableAndStoreAndLock(receiptId)
+			.map(receiptEntity -> ReceiptMapper.toReceipt(receiptEntity,
+				TableMapper.toTable(receiptEntity.getTable(), (Store)null),
+				SaleMapper.toSale(receiptEntity.getSale(), StoreMapper.toStore(receiptEntity.getSale().getStore()))));
+	}
+
+	@Override
 	public List<Receipt> getNonStopReceiptsWithStoreAndLock(List<Long> receiptIds) {
 		return receiptJpaRepository.findNonStopReceiptsByIdWithStoreAndLock(receiptIds)
 			.stream()
@@ -90,8 +98,8 @@ public class ReceiptRepositoryImpl implements ReceiptRepository {
 	}
 
 	@Override
-	public Slice<Receipt> getCustomerReceiptSlice(Pageable pageable, Long customerId) {
-		return receiptJpaRepository.findCustomerReceiptSliceWithStore(pageable, customerId)
+	public Slice<Receipt> getCustomerReceiptSlice(int pageSize, Long lastReceiptId, Long customerId) {
+		return receiptJpaRepository.findCustomerReceiptSliceWithStore(pageSize, lastReceiptId, customerId)
 			.map(receiptEntity -> ReceiptMapper.toReceipt(receiptEntity, null,
 				SaleMapper.toSale(receiptEntity.getSale(), StoreMapper.toStore(receiptEntity.getSale().getStore()))));
 	}

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepository.java
@@ -18,18 +18,22 @@ public interface ReceiptQueryDslRepository {
 
 	List<ReceiptEntity> findStopReceiptsByIdWithStore(List<Long> receiptIds);
 
+	Optional<ReceiptEntity> findNonStopReceiptsByIdWithTableAndStoreAndLock(Long receiptId);
+
 	List<ReceiptEntity> findNonStopReceiptsByIdWithStoreAndLock(List<Long> receiptIds);
 
 	Page<ReceiptEntity> findAdjustedReceiptPageBySaleId(Pageable pageable, Long saleId);
 
 	ReceiptEntity findNonAdjustReceipt(Long tableId);
 
-	Slice<ReceiptEntity> findCustomerReceiptSliceWithStore(Pageable pageable, Long customerId);
+	Slice<ReceiptEntity> findCustomerReceiptSliceWithStore(int pageSize, Long lastReceiptId, Long customerId);
 
 	Optional<ReceiptEntity> findByIdWithOrders(Long receiptId);
 
 	void restartReceipts(List<Receipt> receipts);
 
 	void adjustReceipts(List<Receipt> receipts);
+
+	void startReceiptUsage(Long receiptId);
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepositoryImpl.java
@@ -143,7 +143,8 @@ public class ReceiptQueryDslRepositoryImpl implements ReceiptQueryDslRepository 
 
 	@Override
 	public Optional<ReceiptEntity> findByIdWithOrders(Long receiptId) {
-		ReceiptEntity receiptEntity = jpaQueryFactory.selectFrom(qReceiptEntity)
+		ReceiptEntity receiptEntity = jpaQueryFactory
+			.selectFrom(qReceiptEntity).distinct()
 			.join(qReceiptEntity.orders).fetchJoin()
 			.where(qReceiptEntity.id.eq(receiptId))
 			.fetchOne();

--- a/infra/rdb/pos/src/test/java/com/pos/menu/repository/MenuRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/menu/repository/MenuRepositoryImplTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.pos.fixtures.menu.MenuCategoryEntityFixture;
@@ -135,13 +134,12 @@ class MenuRepositoryImplTest extends RepositoryTest {
 	@Nested
 	@DisplayName("메뉴 슬라이스 조회")
 	class getMenuSlice {
-		private Pageable pageable;
+		private int pageSize = 5;
 		private MenuInfo lastMenuInfo;
 		private Long menuCategoryId;
 
 		@BeforeEach
 		void setUp() {
-			pageable = Pageable.ofSize(5);
 			menuCategoryId = savedMenuCategory.getMenuCategoryInfo().getId();
 		}
 
@@ -161,7 +159,7 @@ class MenuRepositoryImplTest extends RepositoryTest {
 			lastMenuInfo = MenuInfoFixture.GENERAL_MENU_INFO();
 
 			// when
-			Slice<MenuInfo> menuInfos = menuRepository.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+			Slice<MenuInfo> menuInfos = menuRepository.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId);
 
 			// then
 			assertSoftly(softly -> {
@@ -188,7 +186,7 @@ class MenuRepositoryImplTest extends RepositoryTest {
 			lastMenuInfo = null;
 
 			// when
-			Slice<MenuInfo> menuInfos = menuRepository.getMenuSlice(pageable, lastMenuInfo, menuCategoryId);
+			Slice<MenuInfo> menuInfos = menuRepository.getMenuSlice(pageSize, lastMenuInfo, menuCategoryId);
 
 			// then
 			assertSoftly(softly -> {
@@ -212,7 +210,7 @@ class MenuRepositoryImplTest extends RepositoryTest {
 		MenuInfo patchMenuInfo = MenuInfoFixture.PATCH_MENU_INFO(menuInfo);
 
 		// when
-		MenuInfo savedMenuInfo = menuRepository.patchMenu(patchMenuInfo);
+		MenuInfo savedMenuInfo = menuRepository.patchMenuInfo(patchMenuInfo);
 
 		// then
 		assertSoftly(softly -> {


### PR DESCRIPTION
🍀 작업사항
---

### 1️⃣ Order, OrderMenu 도메인 로직 리팩토링
- (OrderService) 장바구니 기반 Order 추가 api 제작
- (OrderService) 영업별 영수증 리스트 조회 api 제작
- (OrderMenuService)OrderMenu 상태 추가 및 변경 api 제작 및 메서드 매개변수 수정
  - OrderMenuStatus : ORDERED(주문 접수 전 상태), COOKING(주문 접수 후 조리상태), CANCELD(취소 상태), COMPLETED(조리 완료 상태)
  - 개별 주문 메뉴의 상태 변경은 취소, 완료, 재조리 상태변경을 할 수 있도록 구현하였음
  - 주문 메뉴가 취소 또는 완료될 경우 이벤트를 발행하여 해당 주문의 모든 주문 메뉴 중 ORDERED, COOKING 상태가 남아있는지 확인 후, 남아있지 않으면 주문을 COMPLETED 시키도록 하였음(OrderEventListener)

### 2️⃣ Order, OrderMenu 인프라 로직 구현
- (OrderRepositoryImpl) 영수증의 첫 번째 order 저장 시 시작 시간 기록하도록 구현 
- 주문 전체 금액 산정 방법(Orders 컬럼 totalPrice)
  - 처음 주문이 들어오면 모든 주문 메뉴의 가격 및 개수를 계산하여 저장
  - (OrderMenuService.patchOrderMenuStatus()) 개별 주문 메뉴 취소 시 대상 메뉴의 가격과 개수를 계산하여 전체 주문 금액에서 뺴도록 함
  - (OrderMenuService.patchOrderMenuStatus()) 개별 주문 메뉴 재조리 시 다시 전체 주문 금액에 추가하도록 함
  - (OrderMenuService.postOrderMenu()) 주문에 주문 메뉴 추가 시 전체 주문 금액에서 더하도록 함
  - (OrderMenuService.deleteOrderMenu()) 주문에 주문 메뉴 삭제 시 전체 주문 금액에서 뺴도록 함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 주문 메뉴 상태(조리중, 취소, 완료 등) 관리 및 상태 변경 기능이 추가되었습니다.
  - 주문 생성 시 장바구니 기반/비장바구니 기반 주문 등록이 분리되어 더욱 명확해졌습니다.
  - 주문/주문 메뉴 상태 변경 시 이벤트 기반 자동 완료 처리 기능이 도입되었습니다.

- **기능 개선**
  - 메뉴, 주문, 영수증 등 목록 조회 시 페이지네이션 방식이 개선되어 더 효율적인 조회가 가능합니다.
  - 주문, 주문 메뉴, 메뉴 등 주요 엔티티의 상태 및 정보 변경이 더욱 세분화되고 명확해졌습니다.
  - 오류 코드가 세분화되어, 상황별로 더 정확한 안내 메시지가 제공됩니다.

- **버그 수정**
  - 주문 상태 관련 영문 표기 일관성(예: CANCELLED → CANCELED) 문제가 수정되었습니다.

- **테스트**
  - 변경된 기능 및 인터페이스에 맞춰 테스트 코드가 보강 및 정비되었습니다.

- **기타**
  - 내부 코드 구조가 리팩토링되어 유지보수성과 확장성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->