### PR TITLE
기존 리뷰 api 오류 수정 및 store 도메인에 상세 이미지 url list 추가

### DIFF
--- a/application/auth/README.md
+++ b/application/auth/README.md
@@ -1,0 +1,198 @@
+# OIDC 구현 개발 가이드
+
+## 1. OIDC 개요
+
+OIDC(OpenID Connect)는 OAuth 2.0 프로토콜 기반의 인증 프로토콜이다. 카카오, 구글, 애플과 같은 제공자에서 사용자 인증을 처리하고, 이를 우리 서비스에서 활용할 수 있게 한다.
+핵심 개념:
+
+- **ID Token**: JWT 형식의 사용자 인증 정보 토큰
+- **클레임(Claims)**: ID Token에 포함된 사용자 정보
+- **Provider**: 인증 서비스 제공자 (카카오, 구글, 애플)
+
+## 2. 구현 클래스 설명
+
+### 2.1 OidcProvider (enum)
+
+``` java
+public enum OidcProvider {
+    KAKAO,
+    GOOGLE,
+    APPLE;
+}
+```
+
+- OIDC 인증 제공자를 표현하는 열거형
+
+### 2.2 OidcPayload (record)
+
+``` java
+public record OidcPayload(
+    /* issuer */
+    String iss,
+    /* client id */
+    String aud,
+    /* oauth provider account unique id */
+    String sub,
+    String email
+) {}
+```
+
+- ID Token에서 추출한 정보를 담는 클래스
+- `iss`: 발급자 URL
+- `aud`: 클라이언트 ID
+- `sub`: 사용자 식별자
+- `email`: 사용자 이메일
+
+### 2.3 JwtOidcProvider
+
+JWT 형식의 ID Token을 처리하는 클래스
+주요 기능:
+
+- ID Token 헤더에서 KID(Key ID) 추출
+- 공개키로 ID Token 검증
+- ID Token의 페이로드 추출
+- JWT 검증 및 파싱
+
+### 2.4 OAuthOidcHelper
+
+다양한 OIDC Provider를 처리하는 헬퍼 클래스
+주요 기능:
+
+- 각 Provider별 Client와 속성 관리
+- Provider에 따른 Client 선택
+- ID Token에서 페이로드 추출
+
+## 3. 인증 흐름
+
+OIDC 인증 흐름:
+
+1. 클라이언트가 Provider에 로그인 요청
+2. 사용자가 Provider에서 인증
+3. Provider가 클라이언트에 ID Token 발급
+4. 클라이언트가 ID Token을 서버에 전달
+5. 서버가 ID Token 검증 후 사용자 인증 처리
+
+## 4. API 개발 가이드
+
+### 4.1 API 엔드포인트 설계
+
+``` 
+POST /api/v1/auth/login/oidc
+```
+
+### 4.2 요청 파라미터
+
+``` json
+{
+  "provider": "KAKAO",
+  "idToken": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAifQ...",
+  "oauthId": "12345678",
+  "nonce": "abc123"
+}
+```
+
+### 4.3 구현 예시
+
+컨트롤러 구현:
+
+``` java
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class OidcAuthController {
+
+    private final OAuthOidcHelper oAuthOidcHelper;
+    private final UserService userService;
+
+    @PostMapping("/login/oidc")
+    public ResponseEntity<LoginResponse> loginWithOidc(@RequestBody OidcLoginRequest request) {
+        // 1. ID Token에서 페이로드 추출
+        OidcPayload payload = oAuthOidcHelper.getPayload(
+            request.getProvider(), 
+            request.getOauthId(), 
+            request.getIdToken(), 
+            request.getNonce()
+        );
+        
+        // 2. 추출한 정보로 사용자 처리 (회원가입/로그인)
+        User user = userService.findOrCreateUser(
+            payload.sub(), 
+            payload.email(), 
+            request.getProvider()
+        );
+        
+        // 3. 인증 토큰 발급
+        String accessToken = tokenService.createAccessToken(user);
+        String refreshToken = tokenService.createRefreshToken(user);
+        
+        // 4. 응답 반환
+        return ResponseEntity.ok(new LoginResponse(accessToken, refreshToken));
+    }
+}
+```
+
+요청 DTO:
+
+``` java
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OidcLoginRequest {
+    private OidcProvider provider;
+    private String idToken;
+    private String oauthId;
+    private String nonce;
+}
+```
+
+### 4.4 OAuthOidcHelper 사용 방법
+
+실제 프로젝트 사용 예시:
+
+``` java
+private final JwtService jwtService;
+private final OAuthOidcHelper oauthOidcHelper;
+private final UserService userService;
+private final NickNameGenerateService nickNameGenerateService;
+
+@Transactional
+public Pair<Long, JwtPair> signUp(OidcProvider provider, SignUpRequest.Oidc request) {
+    // OAuthOidcHelper를 사용하여 ID Token에서 페이로드 추출
+    OidcPayload payload = oauthOidcHelper.getPayload(
+        provider,              // 인증 제공자 (KAKAO, GOOGLE, APPLE)
+        request.oauthId(),     // 사용자 식별자
+        request.idToken(),     // ID Token
+        request.nonce()        // nonce 값
+    );
+
+    // 이메일로 기존 사용자 조회
+    return userService.findByProviderAndEmail(OAuthMapper.fromOidcProvider(provider), payload.email())
+        .map(user -> Pair.of(user.getId(), jwtService.createToken(user))) // 이메일이 존재할 경우
+        .orElseGet(() -> { // 이메일이 존재하지 않을 경우
+            // 새 사용자 생성
+            User oAuthUser = UserMapper.toOAuthUser(
+                nickNameGenerateService.generateRandomNickname(),
+                OAuthMapper.fromOidcProvider(provider),
+                payload.email()
+            );
+            User newUser = userService.registerOAuthUser(oAuthUser);
+            return Pair.of(newUser.getId(), jwtService.createToken(newUser));
+        });
+}
+```
+
+ID Token에서 추출한 정보(특히 이메일)를 사용해 회원가입/로그인 로직을 구현한다.
+
+## 5. 클라이언트 전달 데이터
+
+클라이언트는 다음 데이터를 서버로 전송해야 한다:
+
+1. **Provider**: 인증 제공자 (KAKAO, GOOGLE, APPLE)
+2. **ID Token**: 제공자에서 받은 JWT 형식 토큰
+3. **oauthId**: 제공자가 제공한 사용자 식별자
+4. **nonce**: 인증 요청 시 사용한 임의 문자열 (선택)
+
+각 제공자별 필요 정보:
+
+- **카카오**: ID Token, 사용자 ID
+- **구글**: ID Token, 사용자 ID
+- **애플**: ID Token, 사용자 ID

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/api/ReviewApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/api/ReviewApi.java
@@ -86,8 +86,9 @@ public interface ReviewApi {
 		@RequestParam Long reviewId);
 
 	@Operation(
-		summary = "리뷰 목록 조회 API",
-		description = "리뷰를 커서 기반으로 조회합니다."
+		summary = "가게 리뷰 목록 조회 API",
+		description = "리뷰를 커서 기반으로 조회합니다.\n"
+			+ "리뷰는 최신순으로 정렬되어 있습니다.\n"
 	)
 	@ApiResponse(content = @Content(
 		mediaType = "application/json",
@@ -99,7 +100,7 @@ public interface ReviewApi {
 		)
 	)
 	ResponseEntity<ResponseBody<ReviewsCusorResponse>> getReview(
-		@RequestParam Long receiptId,
+		@RequestParam Long storeId,
 		@RequestParam Long lastReviewId,
 		@RequestParam int size);
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
@@ -39,13 +39,19 @@ public class ReviewController implements ReviewApi {
 		UserPassport userPassport,
 		@RequestBody @Valid ReviewCreateRequest reviewCreateRequest
 	) {
-		Review review = reviewService.postReview(userPassport, reviewCreateRequest.receiptId(),
+		Review review = reviewService.postReview(userPassport, reviewCreateRequest.storeId(),
+			reviewCreateRequest.receiptId(),
 			reviewCreateRequest.getReviewInfo());
 		return ResponseEntity.ok(createSuccessResponse(
 			ReviewIdResponse.from(review)
 		));
 	}
 
+	/**
+	 * @deprecated since 2025-05-08
+	 * 기획상 삭제될 예정.
+	 */
+	@Deprecated(since = "2025-05-08")
 	@PatchMapping("/api/v1/review")
 	@HasRole(userRole = ROLE_USER)
 	@AssignUserPassport

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
@@ -80,13 +80,13 @@ public class ReviewController implements ReviewApi {
 	@GetMapping("/api/v1/reviews")
 	@HasRole(userRole = ROLE_ANONYMOUS)
 	public ResponseEntity<ResponseBody<ReviewsCusorResponse>> getReview(
-		@RequestParam Long receiptId,
+		@RequestParam Long storeId,
 		@RequestParam Long lastReviewId,
 		@RequestParam int size
 	) {
 		return ResponseEntity.ok(createSuccessResponse(
 			ReviewsCusorResponse.from(reviewService.getReviews(
-				receiptId, lastReviewId, size))
+				storeId, lastReviewId, size))
 		));
 	}
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/request/ReviewCreateRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/request/ReviewCreateRequest.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 public record ReviewCreateRequest(
 	@Schema(description = "영수증 ID", example = "1")
 	Long receiptId,
+	@Schema(description = "가게 ID", example = "1")
+	Long storeId,
 	@Schema(description = "리뷰 내용", example = "리뷰 내용")
 	String content,
 	@Schema(description = "리뷰 평점 50점 만점", example = "50")

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/response/ReviewsCusorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/response/ReviewsCusorResponse.java
@@ -17,7 +17,9 @@ public record ReviewsCusorResponse(
 	@Schema(description = "다음 데이터 존재 여부", example = "true")
 	Boolean hasNextPage,
 	@Schema(description = "마지막 reviewId", example = "1")
-	Long lastReviewId
+	Long lastReviewId,
+	@Schema(description = "리뷰 데이터 리스트", example = "리뷰 데이터 리스트")
+	List<ReviewInfoDto> reviewInfoDtos
 ) {
 	@Schema(description = "리뷰 상세 내용 DTO", name = "ReviewInfoDto")
 	@Builder

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/response/ReviewsCusorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/dto/response/ReviewsCusorResponse.java
@@ -11,15 +11,14 @@ import lombok.Builder;
 @Schema(description = "리뷰 커서 응답 DTO", name = "ReviewsCusorResponse")
 @Builder
 public record ReviewsCusorResponse(
+	@Schema(description = "리뷰 데이터 리스트", example = "리뷰 데이터 리스트")
 	List<ReviewInfoDto> reviewsContents,
 	@Schema(description = "데이터 수", example = "10")
 	Integer totalCount,
 	@Schema(description = "다음 데이터 존재 여부", example = "true")
 	Boolean hasNextPage,
 	@Schema(description = "마지막 reviewId", example = "1")
-	Long lastReviewId,
-	@Schema(description = "리뷰 데이터 리스트", example = "리뷰 데이터 리스트")
-	List<ReviewInfoDto> reviewInfoDtos
+	Long lastReviewId
 ) {
 	@Schema(description = "리뷰 상세 내용 DTO", name = "ReviewInfoDto")
 	@Builder

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/api/SaleApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/api/SaleApi.java
@@ -13,7 +13,9 @@ import com.response.ResponseBody;
 import domain.pos.member.entity.UserPassport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @Schema(
 	name = "SaleApi",
@@ -24,6 +26,9 @@ public interface SaleApi {
 		summary = "판매 시작",
 		description = "판매를 시작합니다."
 	)
+	@ApiResponse(content = @Content(
+		mediaType = "application/json",
+		schema = @Schema(implementation = SaleIdResponse.class)))
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
 			responseClass = SaleIdResponse.class,

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/controller/SaleController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/controller/SaleController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.application.presentation.sale.api.SaleApi;
 import com.application.presentation.sale.dto.response.SaleIdResponse;
 import com.authorization.AssignUserPassport;
 import com.authorization.HasRole;
@@ -20,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class SaleController {
+public class SaleController implements SaleApi {
 	private final SaleService saleService;
 
 	@PostMapping("/api/v1/sale/open")

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -95,4 +95,23 @@ public interface StoreApi {
 	ResponseEntity<ResponseBody<Void>> deleteStore(
 		@Parameter(hidden = true) UserPassport userPassport,
 		@RequestParam final Long storeId);
+
+	@Operation(
+		summary = "가게 상세 이미지 업로드 API",
+		description = "가게의 상세 이미지를 업로드합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "가게 이미지 업로드 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_STORE),
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_EQUAL_STORE_OWNER)
+		}
+	)
+	ResponseEntity<ResponseBody<Void>> uploadStoreImage(
+		@Parameter(hidden = true) UserPassport userPassport,
+		@Schema(description = "가게 고유 ID", example = "1") @RequestParam final Long storeId,
+		@Schema(description = "이미지 URL", example = "https://example.com/image.jpg") @RequestParam final String detailImageUrl);
+
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.application.global.config.swagger.ApiErrorResponseExplanation;
 import com.application.global.config.swagger.ApiResponseExplanations;
 import com.application.global.config.swagger.ApiSuccessResponseExplanation;
+import com.application.presentation.store.dto.request.StoreCursorRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
+import com.application.presentation.store.dto.response.StoreCursorResponse;
 import com.application.presentation.store.dto.response.StoreIdResponse;
 import com.application.presentation.store.dto.response.StoreInfoResponse;
 import com.exception.ErrorCode;
@@ -132,5 +134,16 @@ public interface StoreApi {
 		@Parameter(hidden = true) UserPassport userPassport,
 		@Schema(description = "가게 고유 ID", example = "1") @RequestParam final Long storeId,
 		@Schema(description = "삭제할 이미지 URL", example = "https://example.com/image.jpg") @RequestParam final String detailImageUrl);
+
+	@Operation(
+		summary = "가게 목록 커서 조회 API",
+		description = "리뷰 수 DESC 기준으로 가게 리스트를 무한 스크롤 방식으로 조회합니다."
+	)
+	@ApiResponse(content = @Content(
+		mediaType = "application/json",
+		schema = @Schema(implementation = StoreCursorResponse.class)))
+	ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
+		@RequestBody @Valid StoreCursorRequest storeCursorRequest
+	);
 
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -114,4 +114,23 @@ public interface StoreApi {
 		@Schema(description = "가게 고유 ID", example = "1") @RequestParam final Long storeId,
 		@Schema(description = "이미지 URL", example = "https://example.com/image.jpg") @RequestParam final String detailImageUrl);
 
+	@Operation(
+		summary = "가게 상세 이미지 삭제 API",
+		description = "가게의 상세 이미지를 삭제합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "가게 이미지 삭제 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_STORE),
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_EQUAL_STORE_OWNER),
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_STORE_IMAGE)
+		}
+	)
+	ResponseEntity<ResponseBody<Void>> deleteStoreImage(
+		@Parameter(hidden = true) UserPassport userPassport,
+		@Schema(description = "가게 고유 ID", example = "1") @RequestParam final Long storeId,
+		@Schema(description = "삭제할 이미지 URL", example = "https://example.com/image.jpg") @RequestParam final String detailImageUrl);
+
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -6,6 +6,7 @@ import static domain.pos.member.entity.UserRole.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,7 +60,7 @@ public class StoreController implements StoreApi {
 	@GetMapping("/api/v1/stores")
 	@HasRole(userRole = ROLE_ANONYMOUS)
 	public ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
-		@RequestBody @Valid final StoreCursorRequest storeCursorRequest
+		@ModelAttribute @Valid final StoreCursorRequest storeCursorRequest
 	) {
 		return ResponseEntity
 			.ok(createSuccessResponse(StoreCursorResponse.from(

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -79,4 +79,15 @@ public class StoreController implements StoreApi {
 			.ok(createSuccessResponse());
 	}
 
+	@PostMapping("/api/v1/store/image")
+	@HasRole(userRole = ROLE_OWNER)
+	@AssignUserPassport
+	public ResponseEntity<ResponseBody<Void>> uploadStoreImage(
+		UserPassport userPassport,
+		@RequestParam @Valid final Long storeId,
+		@RequestParam @Valid final String detailImageUrl) {
+		storeService.postDetailImage(userPassport, storeId, detailImageUrl);
+		return ResponseEntity
+			.ok(createSuccessResponse());
+	}
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.application.presentation.store.api.StoreApi;
+import com.application.presentation.store.dto.request.StoreCursorRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
+import com.application.presentation.store.dto.response.StoreCursorResponse;
 import com.application.presentation.store.dto.response.StoreIdResponse;
 import com.application.presentation.store.dto.response.StoreInfoResponse;
 import com.authorization.AssignUserPassport;
@@ -51,6 +53,18 @@ public class StoreController implements StoreApi {
 		return ResponseEntity
 			.ok(createSuccessResponse(
 				StoreInfoResponse.of(storeService.findStore(storeId))
+			));
+	}
+
+	@GetMapping("/api/v1/stores")
+	@HasRole(userRole = ROLE_ANONYMOUS)
+	public ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
+		@RequestBody @Valid final StoreCursorRequest storeCursorRequest
+	) {
+		return ResponseEntity
+			.ok(createSuccessResponse(StoreCursorResponse.from(
+				storeService.findStores(storeCursorRequest.lastReviewCount(), storeCursorRequest.lastStoreId(),
+					storeCursorRequest.size()))
 			));
 	}
 

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -90,4 +90,16 @@ public class StoreController implements StoreApi {
 		return ResponseEntity
 			.ok(createSuccessResponse());
 	}
+
+	@DeleteMapping("/api/v1/store/image")
+	@HasRole(userRole = ROLE_OWNER)
+	@AssignUserPassport
+	public ResponseEntity<ResponseBody<Void>> deleteStoreImage(
+		UserPassport userPassport,
+		@RequestParam @Valid final Long storeId,
+		@RequestParam @Valid final String detailImageUrl) {
+		storeService.deleteDetailImage(userPassport, storeId, detailImageUrl);
+		return ResponseEntity
+			.ok(createSuccessResponse());
+	}
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/request/StoreCursorRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/request/StoreCursorRequest.java
@@ -1,0 +1,19 @@
+package com.application.presentation.store.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+
+@Schema(name = "StoreCursorRequest", description = "가게 커서 요청")
+@Builder
+public record StoreCursorRequest(
+	@Schema(description = "마지막 리뷰 수 만약 첫 조회면 null", example = "131")
+	@Nullable
+	Long lastReviewCount,
+	@Schema(description = "마지막 가게 ID 만약 첫 조회면 null", example = "1")
+	@Nullable
+	Long lastStoreId,
+	@Schema(description = "가게 개수", example = "10")
+	Integer size
+) {
+}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
@@ -61,8 +61,8 @@ public record StoreCursorResponse(
 		return StoreCursorResponse.builder()
 			.totalCount(size)
 			.hasNextPage(storeHeadDtos.hasNext())
-			.lastReviewCount(Long.valueOf(storeHeadDtos.getContent().isEmpty() ? null :
-				storeHeadDtos.getContent().get(size - 1).getReviewCount()))
+			.lastReviewCount(storeHeadDtos.getContent().isEmpty() ? null :
+				Long.valueOf(storeHeadDtos.getContent().get(size - 1).getReviewCount()))
 			.lastStoreId(storeHeadDtos.getContent().isEmpty() ? null :
 				storeHeadDtos.getContent().get(size - 1).getStoreId())
 			.storeInfoDtos(storeHeadDtos.getContent().stream()

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
@@ -1,0 +1,73 @@
+package com.application.presentation.store.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import domain.pos.store.entity.dto.StoreHeadDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(name = "StoreCursorResponse", description = "가게 커서 응답")
+@Builder
+public record StoreCursorResponse(
+	@Schema(description = "데이터 수", example = "10")
+	Integer totalCount,
+	@Schema(description = "다음 데이터 존재 여부", example = "true")
+	Boolean hasNextPage,
+	@Schema(description = "마지막 데이터의 review 수", example = "30")
+	Long lastReviewCount,
+	@Schema(description = "마지막 가게 ID", example = "1")
+	Long lastStoreId,
+	@Schema(description = "가게 데이터 리스트", example = "가게 데이터 리스트")
+	List<StoreInfoDto> storeInfoDtos
+) {
+	@Schema(name = "StoreInfoDto", description = "가게 데이터")
+	@Builder
+	public record StoreInfoDto(
+		@Schema(description = "가게 ID", example = "1")
+		Long storeId,
+		@Schema(description = "가게 이름", example = "가게 이름")
+		String storeName,
+		@Schema(description = "가게 오픈 여부", example = "true")
+		Boolean isOpened,
+		@Schema(description = "가게 대표 이미지 URL", example = "https://example.com/image.jpg")
+		String headImageUrl,
+		@Schema(description = "가게 설명", example = "가게 설명")
+		String description,
+		@Schema(description = "가게 평균 평점", example = "43")
+		Integer ratingAverage,
+		@Schema(description = "가게 리뷰 수", example = "10")
+		Integer reviewCount,
+		@Schema(description = "가게 상세 이미지 URL 리스트", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+		List<String> storeDetailImageUrls
+	) {
+		public static StoreInfoDto from(StoreHeadDto storeHeadDto) {
+			return StoreInfoDto.builder()
+				.storeId(storeHeadDto.getStoreId())
+				.storeName(storeHeadDto.getStoreName())
+				.isOpened(storeHeadDto.getIsOpened())
+				.headImageUrl(storeHeadDto.getHeadImageUrl())
+				.description(storeHeadDto.getDescription())
+				.ratingAverage(storeHeadDto.getRatingAverage())
+				.reviewCount(storeHeadDto.getReviewCount())
+				.storeDetailImageUrls(storeHeadDto.getStoreDetailImageUrls())
+				.build();
+		}
+	}
+
+	public static StoreCursorResponse from(Slice<StoreHeadDto> storeHeadDtos) {
+		int size = storeHeadDtos.getContent().size();
+		return StoreCursorResponse.builder()
+			.totalCount(size)
+			.hasNextPage(storeHeadDtos.hasNext())
+			.lastReviewCount(Long.valueOf(storeHeadDtos.getContent().isEmpty() ? null :
+				storeHeadDtos.getContent().get(size - 1).getReviewCount()))
+			.lastStoreId(storeHeadDtos.getContent().isEmpty() ? null :
+				storeHeadDtos.getContent().get(size - 1).getStoreId())
+			.storeInfoDtos(storeHeadDtos.getContent().stream()
+				.map(StoreInfoDto::from)
+				.toList())
+			.build();
+	}
+}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
@@ -1,5 +1,7 @@
 package com.application.presentation.store.dto.response;
 
+import java.util.List;
+
 import domain.pos.store.entity.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -30,7 +32,9 @@ public record StoreInfoResponse(
 	@Schema(description = "가게 테이블 시간", example = "30")
 	Integer tableTime,
 	@Schema(description = "가게 테이블 비용", example = "10000")
-	Integer tableCost
+	Integer tableCost,
+	@Schema(description = "가게 상세 이미지 URL", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+	List<String> detailImageUrls
 ) {
 	public static StoreInfoResponse of(Store store) {
 		return StoreInfoResponse.builder()
@@ -46,6 +50,7 @@ public record StoreInfoResponse(
 			.university(store.getStoreInfo().getUniversity())
 			.tableTime(store.getStoreInfo().getTableTime())
 			.tableCost(store.getStoreInfo().getTableCost())
+			.detailImageUrls(store.getDetailImageUrls())
 			.build();
 	}
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreInfoResponse.java
@@ -13,10 +13,6 @@ public record StoreInfoResponse(
 	Long storeId,
 	@Schema(description = "가게 오픈 여부", example = "true")
 	boolean isOpen,
-	@Schema(description = "점주 고유 ID", example = "1")
-	Long userId,
-	@Schema(description = "점주 닉네임", example = "강민기")
-	String userNickname,
 	@Schema(description = "가게 이름", example = "가게 이름")
 	String storeName,
 	@Schema(description = "가게 위도", example = "37.123456")
@@ -40,8 +36,6 @@ public record StoreInfoResponse(
 		return StoreInfoResponse.builder()
 			.storeId(store.getStoreId())
 			.isOpen(store.getIsOpen())
-			.userId(store.getOwnerPassport().getUserId())
-			.userNickname(store.getOwnerPassport().getUserNickname())
 			.storeName(store.getStoreInfo().getStoreName())
 			.latitude(store.getStoreInfo().getLocation().getX())
 			.longitude(store.getStoreInfo().getLocation().getY())

--- a/common/base/src/main/java/com/exception/ErrorCode.java
+++ b/common/base/src/main/java/com/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
 	NOT_EQUAL_STORE_OWNER(HttpStatus.CONFLICT, "STORE_0001", "해당 가게의 점주가 아닙니다"),
 	NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "STORE_0002", "해당 가게를 찾을 수 없습니다"),
 	CONFLICT_OPEN_STORE(HttpStatus.CONFLICT, "STORE_0003", "해당 가게 활성화 여부가 충돌된 요청입니다"),
-	CONFLICT_CLOSE_STORE(HttpStatus.CONFLICT, "STORE_004", "가게가 이미 종료되었습니다."),
+	CONFLICT_CLOSE_STORE(HttpStatus.CONFLICT, "STORE_0004", "가게가 이미 종료되었습니다."),
+	NOT_FOUND_STORE_IMAGE(HttpStatus.NOT_FOUND, "STORE_0005", "존재하지 않는 가게 이미지입니다."),
 
 	// Auth
 	INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0001", "해당 ID 토큰은 유효하지 않습니다."),

--- a/domain/domain-pos/src/main/java/domain/pos/review/entity/Review.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/entity/Review.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import domain.pos.member.entity.UserPassport;
 import domain.pos.receipt.entity.Receipt;
+import domain.pos.store.entity.Store;
 import lombok.Getter;
 
 @Getter
@@ -12,20 +13,23 @@ public class Review {
 	private final ReviewInfo reviewInfo;
 	private final UserPassport userPassport;
 	private final Receipt receipt;
+	private final Store store;
 	private final LocalDateTime createdAt;
 
-	private Review(Long reviewId, ReviewInfo reviewInfo, UserPassport userPassport, Receipt receipt,
+	private Review(Long reviewId, ReviewInfo reviewInfo, UserPassport userPassport, Receipt receipt, Store store,
 		LocalDateTime createdAt) {
 		this.reviewId = reviewId;
 		this.reviewInfo = reviewInfo;
 		this.userPassport = userPassport;
 		this.receipt = receipt;
+		this.store = store;
 		this.createdAt = createdAt;
 	}
 
 	public static Review of(Long reviewId, ReviewInfo reviewInfo, UserPassport userPassport, Receipt receipt,
+		Store store,
 		LocalDateTime createdAt) {
-		return new Review(reviewId, reviewInfo, userPassport, receipt, createdAt);
+		return new Review(reviewId, reviewInfo, userPassport, receipt, store, createdAt);
 	}
 
 	public boolean isUser(UserPassport userPassport) {

--- a/domain/domain-pos/src/main/java/domain/pos/review/implement/ReviewReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/implement/ReviewReader.java
@@ -23,7 +23,7 @@ public class ReviewReader {
 		return reviewRepository.findById(reviewId);
 	}
 
-	public Slice<Review> getReviews(Long receiptId, Long lastReviewId, int size) {
-		return reviewRepository.getReviewsWithUser(receiptId, lastReviewId, size);
+	public Slice<Review> getReviews(Long storeId, Long lastReviewId, int size) {
+		return reviewRepository.getReviewsWithUser(storeId, lastReviewId, size);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/review/implement/ReviewWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/implement/ReviewWriter.java
@@ -14,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 public class ReviewWriter {
 	private final ReviewRepository reviewRepository;
 
-	public Review postReview(UserPassport userPassport, ReceiptInfo receiptInfo, ReviewInfo reviewInfo) {
-		return reviewRepository.createReview(userPassport, receiptInfo, reviewInfo);
+	public Review postReview(UserPassport userPassport, Long storeId, ReceiptInfo receiptInfo, ReviewInfo reviewInfo) {
+		return reviewRepository.createReview(userPassport, storeId, receiptInfo, reviewInfo);
 	}
 
 	public Review updateReview(Review review, ReviewInfo updateReviewInfo) {

--- a/domain/domain-pos/src/main/java/domain/pos/review/repository/ReviewRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/repository/ReviewRepository.java
@@ -22,5 +22,5 @@ public interface ReviewRepository {
 
 	void deleteReview(Review review);
 
-	Slice<Review> getReviewsWithUser(Long receiptId, Long lastReviewId, int size);
+	Slice<Review> getReviewsWithUser(Long storeId, Long lastReviewId, int size);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/review/repository/ReviewRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/repository/ReviewRepository.java
@@ -12,7 +12,7 @@ import domain.pos.review.entity.ReviewInfo;
 
 @Repository
 public interface ReviewRepository {
-	Review createReview(UserPassport userPassport, ReceiptInfo receiptInfo, ReviewInfo reviewInfo);
+	Review createReview(UserPassport userPassport, Long storeId, ReceiptInfo receiptInfo, ReviewInfo reviewInfo);
 
 	boolean existsReview(Long receiptId, UserPassport userPassport);
 

--- a/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
@@ -64,8 +64,8 @@ public class ReviewService {
 		reviewWriter.deleteReview(review);
 	}
 
-	public Slice<Review> getReviews(final Long receiptId, final Long lastReviewId, final int size) {
-		return reviewReader.getReviews(receiptId, lastReviewId, size);
+	public Slice<Review> getReviews(final Long storeId, final Long lastReviewId, final int size) {
+		return reviewReader.getReviews(storeId, lastReviewId, size);
 	}
 
 }

--- a/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
@@ -13,6 +13,7 @@ import domain.pos.review.entity.Review;
 import domain.pos.review.entity.ReviewInfo;
 import domain.pos.review.implement.ReviewReader;
 import domain.pos.review.implement.ReviewWriter;
+import domain.pos.store.implement.StoreValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,8 +24,11 @@ public class ReviewService {
 	private final ReceiptReader receiptReader;
 	private final ReviewWriter reviewWriter;
 	private final ReviewReader reviewReader;
+	private final StoreValidator storeValidator;
 
-	public Review postReview(final UserPassport userPassport, final Long receiptId, final ReviewInfo reviewInfo) {
+	public Review postReview(final UserPassport userPassport, final Long storeId, final Long receiptId,
+		final ReviewInfo reviewInfo) {
+		storeValidator.validateStore(storeId);
 		ReceiptInfo receiptInfo = receiptReader.getReceiptInfo(receiptId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.RECEIPT_NOT_FOUND));
 		if (!receiptInfo.isAdjustment()) {
@@ -33,9 +37,14 @@ public class ReviewService {
 		if (reviewReader.isExistsReview(receiptId, userPassport)) {
 			throw new ServiceException(ErrorCode.REVIEW_ALREADY_EXISTS);
 		}
-		return reviewWriter.postReview(userPassport, receiptInfo, reviewInfo);
+		return reviewWriter.postReview(userPassport, storeId, receiptInfo, reviewInfo);
 	}
 
+	/**
+	 * @deprecated since 2025-05-08
+	 * 기획상 사용 안될 예정
+	 */
+	@Deprecated(since = "2025-05-08")
 	public Review updateReview(final UserPassport userPassport, final Long reviewId,
 		final ReviewInfo updateReviewInfo) {
 		Review review = reviewReader.getReview(reviewId)

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
@@ -19,7 +19,7 @@ public class Store {
 		this.isOpen = isOpen;
 		this.storeInfo = storeInfo;
 		this.ownerPassport = ownerPassport;
-		this.detailImageUrls = detailImageUrls;
+		this.detailImageUrls = detailImageUrls != null ? List.copyOf(detailImageUrls) : List.of();
 	}
 
 	public static Store of(Long storeId, Boolean isOpen, StoreInfo storeInfo, UserPassport ownerPassport,

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/Store.java
@@ -1,5 +1,7 @@
 package domain.pos.store.entity;
 
+import java.util.List;
+
 import domain.pos.member.entity.UserPassport;
 import lombok.Getter;
 
@@ -9,20 +11,24 @@ public class Store {
 	private final Boolean isOpen;
 	private final StoreInfo storeInfo;
 	private final UserPassport ownerPassport;
+	private final List<String> detailImageUrls;
 
-	private Store(Long storeId, Boolean isOpen, StoreInfo storeInfo, UserPassport ownerPassport) {
+	private Store(Long storeId, Boolean isOpen, StoreInfo storeInfo, UserPassport ownerPassport,
+		List<String> detailImageUrls) {
 		this.storeId = storeId;
 		this.isOpen = isOpen;
 		this.storeInfo = storeInfo;
 		this.ownerPassport = ownerPassport;
+		this.detailImageUrls = detailImageUrls;
 	}
 
-	public static Store of(Long storeId, Boolean isOpen, StoreInfo storeInfo, UserPassport ownerPassport) {
-		return new Store(storeId, isOpen, storeInfo, ownerPassport);
+	public static Store of(Long storeId, Boolean isOpen, StoreInfo storeInfo, UserPassport ownerPassport,
+		List<String> detailImageUrls) {
+		return new Store(storeId, isOpen, storeInfo, ownerPassport, detailImageUrls);
 	}
 
 	public Store open() {
-		return new Store(this.storeId, true, this.storeInfo, this.ownerPassport);
+		return new Store(this.storeId, true, this.storeInfo, this.ownerPassport, this.detailImageUrls);
 	}
 
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
@@ -24,7 +24,7 @@ public class StoreHeadDto {
 		this.description = description;
 		this.ratingAverage = ratingAverage;
 		this.reviewCount = reviewCount;
-		this.storeDetailImageUrls = storeDetailImageUrls;
+		this.storeDetailImageUrls = storeDetailImageUrls != null ? List.copyOf(storeDetailImageUrls) : List.of();
 	}
 
 	public static StoreHeadDto of(Long storeId, String storeName, Boolean isOpened, String headImageUrl,

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
@@ -1,0 +1,12 @@
+package domain.pos.store.entity.dto;
+
+public class StoreHeadDto {
+	private Long storeId;
+	private String storeName;
+	private Boolean isOpened;
+	private String headImageUrl;
+	private String description;
+	private Integer ratingAverage;
+	private Integer reviewCount;
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
@@ -1,12 +1,35 @@
 package domain.pos.store.entity.dto;
 
-public class StoreHeadDto {
-	private Long storeId;
-	private String storeName;
-	private Boolean isOpened;
-	private String headImageUrl;
-	private String description;
-	private Integer ratingAverage;
-	private Integer reviewCount;
+import java.util.List;
 
+import lombok.Getter;
+
+@Getter
+public class StoreHeadDto {
+	private final Long storeId;
+	private final String storeName;
+	private final Boolean isOpened;
+	private final String headImageUrl;
+	private final String description;
+	private final Integer ratingAverage;
+	private final Integer reviewCount;
+	private final List<String> storeDetailImageUrls;
+
+	private StoreHeadDto(Long storeId, String storeName, Boolean isOpened, String headImageUrl, String description,
+		Integer ratingAverage, Integer reviewCount, List<String> storeDetailImageUrls) {
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.isOpened = isOpened;
+		this.headImageUrl = headImageUrl;
+		this.description = description;
+		this.ratingAverage = ratingAverage;
+		this.reviewCount = reviewCount;
+		this.storeDetailImageUrls = storeDetailImageUrls;
+	}
+
+	public static StoreHeadDto of(Long storeId, String storeName, Boolean isOpened, String headImageUrl,
+		String description, Integer ratingAverage, Integer reviewCount, List<String> storeDetailImageUrls) {
+		return new StoreHeadDto(storeId, storeName, isOpened, headImageUrl, description, ratingAverage, reviewCount,
+			storeDetailImageUrls);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreReader.java
@@ -2,9 +2,11 @@ package domain.pos.store.implement;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import domain.pos.store.entity.Store;
+import domain.pos.store.entity.dto.StoreHeadDto;
 import domain.pos.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -15,5 +17,9 @@ public class StoreReader {
 
 	public Optional<Store> readSingleStore(Long storeId) {
 		return storeRepository.findStoreByStoreId(storeId);
+	}
+
+	public Slice<StoreHeadDto> readStores(Long cursorReviewCount, Long cursorStoreId, int size) {
+		return storeRepository.findStoresCursorOrderByReviewCount(cursorReviewCount, cursorStoreId, size);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -43,4 +43,11 @@ public class StoreValidator {
 			throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
 		}
 	}
+
+	public void validateExistDetailImage(Store previousStore, String imageUrl) {
+		if (!storeRepository.isExistsImageUrl(previousStore.getStoreId(), imageUrl)) {
+			log.warn("해당 Store에 존재하지 않는 이미지 URL: storeId={}, imageUrl={}", previousStore.getStoreId(), imageUrl);
+			throw new ServiceException(ErrorCode.NOT_FOUND_STORE_IMAGE);
+		}
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -7,6 +7,7 @@ import com.exception.ServiceException;
 
 import domain.pos.member.entity.UserPassport;
 import domain.pos.store.entity.Store;
+import domain.pos.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class StoreValidator {
 	private final StoreReader storeReader;
+	private final StoreRepository storeRepository;
 
 	public Store validateStoreOwner(UserPassport ownerPassport, Long queryStoreId) {
 		final Store previousStore = storeReader.readSingleStore(queryStoreId)
@@ -33,5 +35,12 @@ public class StoreValidator {
 	// 가게 소유자와 요청 점주가 같은지 확인
 	private boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
 		return !previousStore.getOwnerPassport().getUserId().equals(ownerId);
+	}
+
+	public void validateStore(Long storeId) {
+		if (!storeRepository.isExistsById(storeId)) {
+			log.warn("해당 Store 존재하지 않음: storeId={}", storeId);
+			throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
+		}
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
@@ -32,4 +32,8 @@ public class StoreWriter {
 	public void postDetailImage(Store previousStore, String imageUrl) {
 		storeRepository.postDetailImage(previousStore, imageUrl);
 	}
+
+	public void deleteDetailImage(Store previousStore, String imageUrl) {
+		storeRepository.deleteDetailImage(previousStore, imageUrl);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreWriter.java
@@ -28,4 +28,8 @@ public class StoreWriter {
 	public Store modifyStoreOpenStatus(Store previousStore) {
 		return storeRepository.changeStoreOpenStatus(previousStore);
 	}
+
+	public void postDetailImage(Store previousStore, String imageUrl) {
+		storeRepository.postDetailImage(previousStore, imageUrl);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -19,4 +19,6 @@ public interface StoreRepository {
 	void deleteStore(Store previousStore);
 
 	Store changeStoreOpenStatus(Store previousStore);
+
+	boolean isExistsById(Long storeId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -21,4 +21,6 @@ public interface StoreRepository {
 	Store changeStoreOpenStatus(Store previousStore);
 
 	boolean isExistsById(Long storeId);
+
+	void postDetailImage(Store previousStore, String imageUrl);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -23,4 +23,8 @@ public interface StoreRepository {
 	boolean isExistsById(Long storeId);
 
 	void postDetailImage(Store previousStore, String imageUrl);
+
+	boolean isExistsImageUrl(Long storeId, String imageUrl);
+
+	void deleteDetailImage(Store previousStore, String imageUrl);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -2,11 +2,13 @@ package domain.pos.store.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import domain.pos.member.entity.UserPassport;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.entity.dto.StoreHeadDto;
 
 @Repository
 public interface StoreRepository {
@@ -27,4 +29,6 @@ public interface StoreRepository {
 	boolean isExistsImageUrl(Long storeId, String imageUrl);
 
 	void deleteDetailImage(Store previousStore, String imageUrl);
+
+	Slice<StoreHeadDto> findStoresCursorOrderByReviewCount(Long cursorReviewCount, Long cursorStoreId, int size);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -55,4 +55,5 @@ public class StoreService {
 		storeWriter.deleteStore(previousStore);
 		log.info("가게 삭제 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
 	}
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -62,4 +62,11 @@ public class StoreService {
 		log.info("가게 상세 이미지 등록 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
 	}
 
+	public void deleteDetailImage(final UserPassport ownerPassport, final Long storeId, final String imageUrl) {
+		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, storeId);
+		storeValidator.validateExistDetailImage(previousStore, imageUrl);
+		storeWriter.deleteDetailImage(previousStore, imageUrl);
+		log.info("가게 상세 이미지 삭제 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
+	}
+
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package domain.pos.store.service;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import com.exception.ErrorCode;
@@ -8,6 +9,7 @@ import com.exception.ServiceException;
 import domain.pos.member.entity.UserPassport;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.entity.dto.StoreHeadDto;
 import domain.pos.store.implement.StoreReader;
 import domain.pos.store.implement.StoreValidator;
 import domain.pos.store.implement.StoreWriter;
@@ -35,6 +37,11 @@ public class StoreService {
 				log.warn("가게 조회 실패: storeId={}", storeId);
 				throw new ServiceException(ErrorCode.NOT_FOUND_STORE);
 			});
+	}
+
+	public Slice<StoreHeadDto> findStores(final Long cursorReviewCount, final Long cursorId, final int size) {
+		log.info("가게 목록 조회: cursorReviewCount={}, size={}", cursorReviewCount, size);
+		return storeReader.readStores(cursorReviewCount, cursorId, size);
 	}
 
 	public Store updateStoreInfo(

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -56,4 +56,10 @@ public class StoreService {
 		log.info("가게 삭제 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
 	}
 
+	public void postDetailImage(final UserPassport ownerPassport, final Long storeId, final String imageUrl) {
+		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, storeId);
+		storeWriter.postDetailImage(previousStore, imageUrl);
+		log.info("가게 상세 이미지 등록 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
+	}
+
 }

--- a/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/store/service/StoreServiceTest.java
@@ -266,4 +266,181 @@ class StoreServiceTest extends ServiceTest {
 			});
 		}
 	}
+
+	@Nested
+	@DisplayName("가게 상세 이미지 등록")
+	class postDetailImage {
+		@Test
+		void 성공() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			Store savedStore = GENERAL_CLOSE_STORE();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doReturn(savedStore)
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
+
+			// when
+			storeService.postDetailImage(queryUserPassport, queryStoreId, imageUrl);
+
+			// then
+			assertSoftly(softly -> {
+				verify(storeValidator)
+					.validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeWriter)
+					.postDetailImage(any(Store.class), eq(imageUrl));
+			});
+		}
+
+		@Test
+		void 실패_유효하지_않는_가게_ID() {
+			// given
+			UserPassport queryOwnerPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator).validateStoreOwner(queryOwnerPassport, queryStoreId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> storeService.postDetailImage(queryOwnerPassport, queryStoreId, imageUrl))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+
+				verify(storeValidator)
+					.validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeWriter, never())
+					.postDetailImage(any(Store.class), anyString());
+			});
+		}
+
+		@Test
+		void 실패_가게ID와_점주ID가_다를시() {
+			// given
+			UserPassport queryDiffOwnerPassport = DIFF_OWNER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator).validateStoreOwner(queryDiffOwnerPassport, queryStoreId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> storeService.postDetailImage(queryDiffOwnerPassport, queryStoreId, imageUrl))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+
+				verify(storeValidator)
+					.validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeWriter, never())
+					.postDetailImage(any(Store.class), anyString());
+			});
+		}
+	}
+
+	@Nested
+	@DisplayName("가게 상세 이미지 삭제")
+	class deleteDetailImage {
+		@Test
+		void 성공() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			Store savedStore = GENERAL_CLOSE_STORE();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doReturn(savedStore)
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
+
+			doNothing()
+				.when(storeValidator).validateExistDetailImage(savedStore, imageUrl);
+
+			// when
+			storeService.deleteDetailImage(queryUserPassport, queryStoreId, imageUrl);
+
+			// then
+			assertSoftly(softly -> {
+				verify(storeValidator).validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeValidator).validateExistDetailImage(any(Store.class), eq(imageUrl));
+				verify(storeWriter).deleteDetailImage(any(Store.class), eq(imageUrl));
+			});
+		}
+
+		@Test
+		void 실패_유효하지_않는_가게_ID() {
+			// given
+			UserPassport queryOwnerPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE))
+				.when(storeValidator).validateStoreOwner(queryOwnerPassport, queryStoreId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> storeService.deleteDetailImage(queryOwnerPassport, queryStoreId, imageUrl))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE);
+
+				verify(storeValidator).validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeValidator, never()).validateExistDetailImage(any(Store.class), anyString());
+				verify(storeWriter, never()).deleteDetailImage(any(Store.class), anyString());
+			});
+		}
+
+		@Test
+		void 실패_가게ID와_점주ID가_다를시() {
+			// given
+			UserPassport queryDiffOwnerPassport = DIFF_OWNER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			String imageUrl = "https://example.com/image.jpg";
+
+			doThrow(new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER))
+				.when(storeValidator).validateStoreOwner(queryDiffOwnerPassport, queryStoreId);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> storeService.deleteDetailImage(queryDiffOwnerPassport, queryStoreId, imageUrl))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EQUAL_STORE_OWNER);
+
+				verify(storeValidator).validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeValidator, never()).validateExistDetailImage(any(Store.class), anyString());
+				verify(storeWriter, never()).deleteDetailImage(any(Store.class), anyString());
+			});
+		}
+
+		@Test
+		void 실패_존재하지_않는_이미지_URL() {
+			// given
+			UserPassport queryUserPassport = OWNER_USER_PASSPORT();
+			Long queryStoreId = GENERAL_CLOSE_STORE().getStoreId();
+			Store savedStore = GENERAL_CLOSE_STORE();
+			String imageUrl = "https://example.com/non-existent-image.jpg";
+
+			doReturn(savedStore)
+				.when(storeValidator).validateStoreOwner(queryUserPassport, queryStoreId);
+
+			doThrow(new ServiceException(ErrorCode.NOT_FOUND_STORE_IMAGE))
+				.when(storeValidator).validateExistDetailImage(savedStore, imageUrl);
+
+			// when -> then
+			assertSoftly(softly -> {
+				softly.assertThatThrownBy(
+						() -> storeService.deleteDetailImage(queryUserPassport, queryStoreId, imageUrl))
+					.isInstanceOf(ServiceException.class)
+					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STORE_IMAGE);
+
+				verify(storeValidator).validateStoreOwner(any(UserPassport.class), any(Long.class));
+				verify(storeValidator).validateExistDetailImage(any(Store.class), anyString());
+				verify(storeWriter, never()).deleteDetailImage(any(Store.class), anyString());
+			});
+		}
+	}
 }

--- a/domain/domain-pos/src/testFixtures/java/fixtures/review/ReviewFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/review/ReviewFixture.java
@@ -1,10 +1,13 @@
 package fixtures.review;
 
+import static fixtures.store.StoreFixture.*;
+
 import java.time.LocalDateTime;
 
 import domain.pos.receipt.entity.Receipt;
 import domain.pos.review.entity.Review;
 import domain.pos.review.entity.ReviewInfo;
+import domain.pos.store.entity.Store;
 import fixtures.member.UserFixture;
 
 public class ReviewFixture {
@@ -12,6 +15,7 @@ public class ReviewFixture {
 	private static final String GENERAL_REVIEW_CONTENT = "review content";
 	private static final Integer GENERAL_REVIEW_RATING = 50;
 	private static final LocalDateTime GENERAL_REVIEW_CREATED_AT = LocalDateTime.now();
+	private static final Store GENERAL_STORE = GENERAL_CLOSE_STORE();
 
 	public static ReviewInfo GENERAL_REVIEW_INFO() {
 		return ReviewInfo.of(
@@ -26,6 +30,7 @@ public class ReviewFixture {
 			GENERAL_REVIEW_INFO(),
 			UserFixture.GENERAL_USER_PASSPORT(),
 			receipt,
+			GENERAL_STORE,
 			GENERAL_REVIEW_CREATED_AT
 		);
 	}

--- a/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreFixture.java
@@ -3,6 +3,8 @@ package fixtures.store;
 import static fixtures.member.UserFixture.*;
 import static fixtures.store.StoreInfoFixture.*;
 
+import java.util.List;
+
 import domain.pos.member.entity.UserPassport;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
@@ -22,12 +24,24 @@ public class StoreFixture {
 	private static final StoreInfo GENERAL_STORE_INFO = GENERAL_STORE_INFO();
 	private static final StoreInfo GENERAL_CHANGED_STORE_INFO = CHANGED_GENERAL_STORE_INFO();
 
+	// 가게 상세 이미지 파일 url
+	private static final String STORE_DETAIL_IMAGE_URL = "https://www.yabam.com/store_detail.jpg";
+	private static final String STORE_DETAIL_IMAGE_URL_2 = "https://www.geumoh.com/store_detail.jpg";
+	private static final List<String> STORE_DETAIL_IMAGE_URL_LIST = List.of(
+		STORE_DETAIL_IMAGE_URL,
+		STORE_DETAIL_IMAGE_URL_2
+	);
+	private static final List<String> STORE_DETAIL_IMAGE_URL_LIST_2 = List.of(
+		STORE_DETAIL_IMAGE_URL
+	);
+
 	public static Store GENERAL_CLOSE_STORE() {
 		return Store.of(
 			STORE_ID,
 			IS_CLOSED,
 			GENERAL_STORE_INFO,
-			GENERAL_STORE_OWNER
+			GENERAL_STORE_OWNER,
+			STORE_DETAIL_IMAGE_URL_LIST
 		);
 	}
 
@@ -36,7 +50,8 @@ public class StoreFixture {
 			STORE_ID,
 			IS_CLOSED,
 			GENERAL_CHANGED_STORE_INFO,
-			GENERAL_STORE_OWNER
+			GENERAL_STORE_OWNER,
+			STORE_DETAIL_IMAGE_URL_LIST
 		);
 	}
 
@@ -45,7 +60,8 @@ public class StoreFixture {
 			STORE_ID,
 			IS_OPEN,
 			GENERAL_STORE_INFO,
-			GENERAL_STORE_OWNER
+			GENERAL_STORE_OWNER,
+			STORE_DETAIL_IMAGE_URL_LIST
 		);
 	}
 
@@ -54,7 +70,8 @@ public class StoreFixture {
 			storeId,
 			IS_CLOSED,
 			storeInfo,
-			ownerPassport
+			ownerPassport,
+			STORE_DETAIL_IMAGE_URL_LIST
 		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/review/entity/ReviewEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/entity/ReviewEntity.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.SQLRestriction;
 import com.pos.global.base.entity.BaseEntity;
 import com.pos.receipt.entity.ReceiptEntity;
 import com.pos.review.entity.vo.ReviewUser;
+import com.pos.store.entity.StoreEntity;
 
 import domain.pos.review.entity.ReviewInfo;
 import jakarta.persistence.Column;
@@ -42,18 +43,25 @@ public class ReviewEntity extends BaseEntity {
 	private Integer rating;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "receipt_id")
+	@JoinColumn(name = "store_id", nullable = false)
+	private StoreEntity store;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "receipt_id", nullable = false)
 	private ReceiptEntity receipt;
 
-	private ReviewEntity(ReviewUser reviewUser, String content, Integer rating, ReceiptEntity receipt) {
+	private ReviewEntity(ReviewUser reviewUser, String content, Integer rating, StoreEntity store,
+		ReceiptEntity receipt) {
 		this.reviewUser = reviewUser;
 		this.content = content;
 		this.rating = rating;
+		this.store = store;
 		this.receipt = receipt;
 	}
 
-	public static ReviewEntity of(ReviewUser reviewUser, String content, Integer rating, ReceiptEntity receipt) {
-		return new ReviewEntity(reviewUser, content, rating, receipt);
+	public static ReviewEntity of(ReviewUser reviewUser, String content, Integer rating, StoreEntity store,
+		ReceiptEntity receipt) {
+		return new ReviewEntity(reviewUser, content, rating, store, receipt);
 	}
 
 	public void changeReviewInfo(ReviewInfo updateReviewInfo) {

--- a/infra/rdb/pos/src/main/java/com/pos/review/mapper/ReviewMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/mapper/ReviewMapper.java
@@ -3,6 +3,7 @@ package com.pos.review.mapper;
 import com.pos.receipt.entity.ReceiptEntity;
 import com.pos.review.entity.ReviewEntity;
 import com.pos.review.entity.vo.ReviewUser;
+import com.pos.store.entity.StoreEntity;
 
 import domain.pos.member.entity.UserPassport;
 import domain.pos.receipt.entity.ReceiptInfo;
@@ -13,14 +14,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class ReviewMapper {
 
-	public static ReviewEntity toReviewEntity(UserPassport userPassport, ReceiptInfo receiptInfo,
+	public static ReviewEntity toReviewEntity(UserPassport userPassport, Long storeId, ReceiptInfo receiptInfo,
 		ReviewInfo reviewInfo) {
 		ReviewUser reviewUser = ReviewUser.of(userPassport.getUserId(), userPassport.getUserNickname());
+		StoreEntity storeEntity = StoreEntity.from(storeId);
 		ReceiptEntity receiptEntity = ReceiptEntity.from(receiptInfo.getReceiptId());
 		return ReviewEntity.of(
 			reviewUser,
 			reviewInfo.getContent(),
 			reviewInfo.getRating(),
+			storeEntity,
 			receiptEntity
 		);
 	}
@@ -30,6 +33,7 @@ public class ReviewMapper {
 			savedReviewEntity.getId(),
 			ReviewInfo.of(savedReviewEntity.getContent(), savedReviewEntity.getRating()),
 			userPassport,
+			null,
 			null,
 			savedReviewEntity.getCreatedAt()
 		);
@@ -41,6 +45,7 @@ public class ReviewMapper {
 			ReviewInfo.of(reviewEntity.getContent(), reviewEntity.getRating()),
 			UserPassport
 				.of(reviewEntity.getReviewUser().getUserId(), reviewEntity.getReviewUser().getUserNickname(), null),
+			null,
 			null,
 			reviewEntity.getCreatedAt()
 		);

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepository.java
@@ -7,5 +7,5 @@ import com.pos.review.entity.ReviewEntity;
 public interface ReviewDslRepository {
 	boolean existsByReceiptIdAndUserId(Long receiptId, Long userId);
 
-	Slice<ReviewEntity> findReviewsWithUser(Long receiptId, Long lastReviewId, int size);
+	Slice<ReviewEntity> findReviewsWithUser(Long reviewId, Long lastReviewId, int size);
 }

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepository.java
@@ -7,5 +7,5 @@ import com.pos.review.entity.ReviewEntity;
 public interface ReviewDslRepository {
 	boolean existsByReceiptIdAndUserId(Long receiptId, Long userId);
 
-	Slice<ReviewEntity> findReviewsWithUser(Long reviewId, Long lastReviewId, int size);
+	Slice<ReviewEntity> findReviewsWithUser(Long storeId, Long lastReviewId, int size);
 }

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
@@ -31,11 +31,11 @@ public class ReviewDslRepositoryImpl implements ReviewDslRepository {
 	}
 
 	@Override
-	public Slice<ReviewEntity> findReviewsWithUser(Long reviewId, Long lastReviewId, int size) {
+	public Slice<ReviewEntity> findReviewsWithUser(Long storeId, Long lastReviewId, int size) {
 		List<ReviewEntity> results = queryFactory
 			.selectFrom(qReviewEntity)
 			.where(qReviewEntity.id.lt(lastReviewId)
-				.and(qReviewEntity.store.id.eq(reviewId)))
+				.and(qReviewEntity.store.id.eq(storeId)))
 			.orderBy(qReviewEntity.id.desc())
 			.limit(size + 1)
 			.fetch();

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
@@ -31,11 +31,11 @@ public class ReviewDslRepositoryImpl implements ReviewDslRepository {
 	}
 
 	@Override
-	public Slice<ReviewEntity> findReviewsWithUser(Long receiptId, Long lastReviewId, int size) {
+	public Slice<ReviewEntity> findReviewsWithUser(Long reviewId, Long lastReviewId, int size) {
 		List<ReviewEntity> results = queryFactory
 			.selectFrom(qReviewEntity)
 			.where(qReviewEntity.id.lt(lastReviewId)
-				.and(qReviewEntity.receipt.id.eq(receiptId)))
+				.and(qReviewEntity.store.id.eq(reviewId)))
 			.orderBy(qReviewEntity.id.desc())
 			.limit(size + 1)
 			.fetch();

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/impl/ReviewRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/impl/ReviewRepositoryImpl.java
@@ -27,8 +27,9 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 	private final ReviewJpaRepository reviewJpaRepository;
 
 	@Override
-	public Review createReview(UserPassport userPassport, ReceiptInfo receiptInfo, ReviewInfo reviewInfo) {
-		ReviewEntity reviewEntity = ReviewMapper.toReviewEntity(userPassport, receiptInfo, reviewInfo);
+	public Review createReview(UserPassport userPassport, Long storeId, ReceiptInfo receiptInfo,
+		ReviewInfo reviewInfo) {
+		ReviewEntity reviewEntity = ReviewMapper.toReviewEntity(userPassport, storeId, receiptInfo, reviewInfo);
 		ReviewEntity savedReviewEntity = reviewJpaRepository.save(reviewEntity);
 		return ReviewMapper.toReview(savedReviewEntity, userPassport);
 	}

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/impl/ReviewRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/impl/ReviewRepositoryImpl.java
@@ -60,8 +60,8 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 	}
 
 	@Override
-	public Slice<Review> getReviewsWithUser(Long receiptId, Long lastReviewId, int size) {
-		Slice<ReviewEntity> reviewsWithUser = reviewJpaRepository.findReviewsWithUser(receiptId, lastReviewId, size);
+	public Slice<Review> getReviewsWithUser(Long storeId, Long lastReviewId, int size) {
+		Slice<ReviewEntity> reviewsWithUser = reviewJpaRepository.findReviewsWithUser(storeId, lastReviewId, size);
 		List<Review> reviews = reviewsWithUser.getContent().stream()
 			.map(reviewEntity -> ReviewMapper.toReview(reviewEntity))
 			.toList();

--- a/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreDetailImageEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreDetailImageEntity.java
@@ -1,0 +1,40 @@
+package com.pos.store.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "store_detail_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreDetailImageEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String imageUrl;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id", nullable = false)
+	private StoreEntity store;
+
+	private StoreDetailImageEntity(String imageUrl, StoreEntity store) {
+		this.imageUrl = imageUrl;
+		this.store = store;
+	}
+
+	public static StoreDetailImageEntity of(String imageUrl, StoreEntity store) {
+		return new StoreDetailImageEntity(imageUrl, store);
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -1,7 +1,10 @@
 package com.pos.store.mapper;
 
 import java.awt.geom.Point2D;
+import java.util.List;
+import java.util.Optional;
 
+import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 
 import domain.pos.member.entity.UserPassport;
@@ -48,7 +51,25 @@ public class StoreMapper {
 			storeEntity.getId(),
 			storeEntity.isOpen(),
 			toStoreInfo(storeEntity),
-			UserPassport.of(storeEntity.getId(), null, null)
+			UserPassport.of(storeEntity.getId(), null, null),
+			null
 		);
+	}
+
+	public static Optional<Store> toStore(List<StoreDetailImageEntity> storeDetailImageEntities) {
+		if (storeDetailImageEntities.isEmpty()) {
+			return Optional.empty();
+		}
+		StoreEntity storeEntity = storeDetailImageEntities.get(0).getStore();
+		List<String> detailImageUrls = storeDetailImageEntities.stream()
+			.map(StoreDetailImageEntity::getImageUrl)
+			.toList();
+		return Optional.of(Store.of(
+			storeEntity.getId(),
+			storeEntity.isOpen(),
+			toStoreInfo(storeEntity),
+			UserPassport.of(storeEntity.getId(), null, null),
+			detailImageUrls
+		));
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreDetailImageJpaRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreDetailImageJpaRepository.java
@@ -1,0 +1,10 @@
+package com.pos.store.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.pos.store.entity.StoreDetailImageEntity;
+
+@Repository
+public interface StoreDetailImageJpaRepository extends JpaRepository<StoreDetailImageEntity, Long> {
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreJpaRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreJpaRepository.java
@@ -4,7 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.pos.store.entity.StoreEntity;
+import com.pos.store.repository.dsl.StoreDslRepository;
 
 @Repository
-public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long> {
+public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long>, StoreDslRepository {
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -95,4 +95,23 @@ public class StoreRepositoryImpl implements StoreRepository {
 			)
 		);
 	}
+
+	@Override
+	public boolean isExistsImageUrl(Long storeId, String imageUrl) {
+		return queryFactory
+			.selectOne()
+			.from(qStoreDetailImageEntity)
+			.where(qStoreDetailImageEntity.imageUrl.eq(imageUrl)
+				.and(qStoreDetailImageEntity.store.id.eq(storeId)))
+			.fetchFirst() != null;
+	}
+
+	@Override
+	@Transactional
+	public void deleteDetailImage(Store previousStore, String imageUrl) {
+		queryFactory
+			.delete(qStoreDetailImageEntity)
+			.where(qStoreDetailImageEntity.imageUrl.eq(imageUrl))
+			.execute();
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -111,7 +111,8 @@ public class StoreRepositoryImpl implements StoreRepository {
 	public void deleteDetailImage(Store previousStore, String imageUrl) {
 		queryFactory
 			.delete(qStoreDetailImageEntity)
-			.where(qStoreDetailImageEntity.imageUrl.eq(imageUrl))
+			.where(qStoreDetailImageEntity.imageUrl.eq(imageUrl)
+				.and(qStoreDetailImageEntity.store.id.eq(previousStore.getStoreId())))
 			.execute();
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -65,4 +65,13 @@ public class StoreRepositoryImpl implements StoreRepository {
 			.execute();
 		return previousStore.open();
 	}
+
+	@Override
+	public boolean isExistsById(Long storeId) {
+		return queryFactory
+			.selectOne()
+			.from(qStoreEntity)
+			.where(qStoreEntity.id.eq(storeId))
+			.fetchFirst() != null;
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.pos.store.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.pos.store.entity.QStoreDetailImageEntity;
 import com.pos.store.entity.QStoreEntity;
+import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 import com.pos.store.mapper.StoreMapper;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,6 +27,7 @@ public class StoreRepositoryImpl implements StoreRepository {
 	private final JPAQueryFactory queryFactory;
 
 	private final QStoreEntity qStoreEntity = QStoreEntity.storeEntity;
+	private final QStoreDetailImageEntity qStoreDetailImageEntity = QStoreDetailImageEntity.storeDetailImageEntity;
 
 	private static final boolean IS_CLOSED = false;
 
@@ -35,8 +39,14 @@ public class StoreRepositoryImpl implements StoreRepository {
 
 	@Override
 	public Optional<Store> findStoreByStoreId(Long storeId) {
-		return storeJpaRepository.findById(storeId)
-			.map(storeEntity -> StoreMapper.toStore(storeEntity));
+		List<StoreDetailImageEntity> storeDetailImageEntities = queryFactory
+			.select(qStoreDetailImageEntity)
+			.from(qStoreDetailImageEntity)
+			.join(qStoreDetailImageEntity.store, qStoreEntity).fetchJoin()
+			.where(qStoreEntity.id.eq(storeId))
+			.fetch();
+
+		return StoreMapper.toStore(storeDetailImageEntities);
 	}
 
 	@Override

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StoreRepositoryImpl implements StoreRepository {
 	private final StoreJpaRepository storeJpaRepository;
+	private final StoreDetailImageJpaRepository storeDetailImageJpaRepository;
 	private final JPAQueryFactory queryFactory;
 
 	private final QStoreEntity qStoreEntity = QStoreEntity.storeEntity;
@@ -83,5 +84,15 @@ public class StoreRepositoryImpl implements StoreRepository {
 			.from(qStoreEntity)
 			.where(qStoreEntity.id.eq(storeId))
 			.fetchFirst() != null;
+	}
+
+	@Override
+	public void postDetailImage(Store previousStore, String imageUrl) {
+		storeDetailImageJpaRepository.save(
+			StoreDetailImageEntity.of(
+				imageUrl,
+				StoreEntity.from(previousStore.getStoreId())
+			)
+		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import domain.pos.member.entity.UserPassport;
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.entity.dto.StoreHeadDto;
 import domain.pos.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -114,5 +116,11 @@ public class StoreRepositoryImpl implements StoreRepository {
 			.where(qStoreDetailImageEntity.imageUrl.eq(imageUrl)
 				.and(qStoreDetailImageEntity.store.id.eq(previousStore.getStoreId())))
 			.execute();
+	}
+
+	@Override
+	public Slice<StoreHeadDto> findStoresCursorOrderByReviewCount(Long cursorReviewCount, Long cursorStoreId,
+		int size) {
+		return storeJpaRepository.findStoreHeadsByReviewCountCursor(cursorReviewCount, cursorStoreId, size);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
@@ -1,0 +1,11 @@
+package com.pos.store.repository.dsl;
+
+import org.springframework.data.domain.Slice;
+
+import domain.pos.store.entity.dto.StoreHeadDto;
+
+public interface StoreDslRepository {
+	Slice<StoreHeadDto> findStoreHeadsByReviewCountCursor(Long cursorReviewCount,
+		Long cursorStoreId,
+		int size);
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
@@ -1,0 +1,111 @@
+package com.pos.store.repository.dsl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.pos.review.entity.QReviewEntity;
+import com.pos.store.entity.QStoreDetailImageEntity;
+import com.pos.store.entity.QStoreEntity;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import domain.pos.store.entity.dto.StoreHeadDto;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreDslRepositoryImpl implements StoreDslRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	private final QStoreEntity store = QStoreEntity.storeEntity;
+	private final QReviewEntity review = QReviewEntity.reviewEntity;
+	private final QStoreDetailImageEntity storeDetailImage = QStoreDetailImageEntity.storeDetailImageEntity;
+
+	@Override
+	public Slice<StoreHeadDto> findStoreHeadsByReviewCountCursor(
+		Long cursorReviewCnt, Long cursorStoreId, int size) {
+		List<Tuple> results = queryFactory
+			.select(
+				store.id,
+				store.name,
+				store.isOpen,
+				store.headImageUrl,
+				store.description,
+				review.id.countDistinct(),
+				review.rating.avg()
+			)
+			.from(review)
+			.rightJoin(review.store, store)
+			.groupBy(store.id)
+			.having(cursorReviewCountOrCursorStoreIdLt(cursorReviewCnt, cursorStoreId))
+			.orderBy(review.id.countDistinct().desc(), store.id.desc())
+			.limit(size + 1)
+			.fetch();
+		return tupleToStoreHeadDto(results, size);
+	}
+
+	private BooleanExpression cursorReviewCountOrCursorStoreIdLt(Long cursorReviewCnt, Long cursorStoreId) {
+		if (cursorReviewCnt == null || cursorStoreId == null) {
+			return null;
+		}
+		return review.id.countDistinct().lt(cursorReviewCnt)
+			.or(review.id.countDistinct().eq(cursorReviewCnt)
+				.and(store.id.lt(cursorStoreId)));
+	}
+
+	private Slice<StoreHeadDto> tupleToStoreHeadDto(List<Tuple> results, int size) {
+		boolean hasNext = results.size() > size;
+		if (hasNext) {
+			results.remove(size);
+		}
+		List<Long> storeIds = results.stream()
+			.map(t -> t.get(store.id))
+			.toList();
+
+		if (storeIds.isEmpty()) {
+			return new SliceImpl<>(List.of(), PageRequest.of(0, size), hasNext);
+		}
+		Map<Long, List<String>> imageUrlMap = getStoreImageUrlsByStoreIds(storeIds);
+
+		List<StoreHeadDto> list = results.stream()
+			.map(tuple -> {
+				int ratingAvg = tuple.get(review.rating.avg()) == null ? 0 : tuple.get(review.rating.avg()).intValue();
+				return StoreHeadDto.of(
+					tuple.get(store.id),
+					tuple.get(store.name),
+					tuple.get(store.isOpen),
+					tuple.get(store.headImageUrl),
+					tuple.get(store.description),
+					ratingAvg,
+					tuple.get(review.id.countDistinct()).intValue(),
+					imageUrlMap.get(tuple.get(store.id)) == null
+						? List.of()
+						: imageUrlMap.get(tuple.get(store.id))
+				);
+			})
+			.toList();
+		return new SliceImpl<>(list, PageRequest.of(0, size), hasNext);
+
+	}
+
+	private Map<Long, List<String>> getStoreImageUrlsByStoreIds(List<Long> storeIds) {
+		return queryFactory
+			.select(storeDetailImage.store.id, storeDetailImage.imageUrl)
+			.from(storeDetailImage)
+			.where(storeDetailImage.store.id.in(storeIds))
+			.fetch()
+			.stream()
+			.collect(Collectors.groupingBy(
+				t -> t.get(storeDetailImage.store.id),
+				Collectors.mapping(t -> t.get(storeDetailImage.imageUrl), Collectors.toList())
+			));
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/table/mapper/TableMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/table/mapper/TableMapper.java
@@ -52,7 +52,7 @@ public class TableMapper {
 			tableEntity.getId(),
 			tableEntity.getTableNumber().getTableNumber(),
 			tableEntity.getIsActive(),
-			Store.of(storeId, null, null, null)
+			Store.of(storeId, null, null, null, null)
 		);
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/builder/BuilderSupporter.java
+++ b/infra/rdb/pos/src/test/java/com/pos/builder/BuilderSupporter.java
@@ -7,6 +7,7 @@ import com.pos.cart.repository.CartJpaRepository;
 import com.pos.menu.repository.jpa.MenuCategoryJpaRepository;
 import com.pos.menu.repository.jpa.MenuJpaRepository;
 import com.pos.sale.repository.SaleJpaRepository;
+import com.pos.store.repository.StoreDetailImageJpaRepository;
 import com.pos.store.repository.StoreJpaRepository;
 import com.pos.table.repository.TableJpaRepository;
 
@@ -30,6 +31,9 @@ public class BuilderSupporter {
 	@Autowired
 	private MenuCategoryJpaRepository menuCategoryJpaRepository;
 
+	@Autowired
+	private StoreDetailImageJpaRepository storeDetailImageJpaRepository;
+
 	public StoreJpaRepository getStoreJpaRepository() {
 		return storeJpaRepository;
 	}
@@ -52,5 +56,9 @@ public class BuilderSupporter {
 
 	public CartJpaRepository getCartJpaRepository() {
 		return cartJpaRepository;
+	}
+
+	public StoreDetailImageJpaRepository getStoreDetailImageJpaRepository() {
+		return storeDetailImageJpaRepository;
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/builder/BuilderSupporter.java
+++ b/infra/rdb/pos/src/test/java/com/pos/builder/BuilderSupporter.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 import com.pos.cart.repository.CartJpaRepository;
 import com.pos.menu.repository.jpa.MenuCategoryJpaRepository;
 import com.pos.menu.repository.jpa.MenuJpaRepository;
+import com.pos.receipt.repository.jpa.ReceiptJpaRepository;
+import com.pos.review.repository.jpa.ReviewJpaRepository;
 import com.pos.sale.repository.SaleJpaRepository;
 import com.pos.store.repository.StoreDetailImageJpaRepository;
 import com.pos.store.repository.StoreJpaRepository;
@@ -34,6 +36,12 @@ public class BuilderSupporter {
 	@Autowired
 	private StoreDetailImageJpaRepository storeDetailImageJpaRepository;
 
+	@Autowired
+	private ReviewJpaRepository reviewJpaRepository;
+
+	@Autowired
+	private ReceiptJpaRepository receiptJpaRepository;
+
 	public StoreJpaRepository getStoreJpaRepository() {
 		return storeJpaRepository;
 	}
@@ -60,5 +68,13 @@ public class BuilderSupporter {
 
 	public StoreDetailImageJpaRepository getStoreDetailImageJpaRepository() {
 		return storeDetailImageJpaRepository;
+	}
+
+	public ReviewJpaRepository getReviewJpaRepository() {
+		return reviewJpaRepository;
+	}
+
+	public ReceiptJpaRepository getReceiptJpaRepository() {
+		return receiptJpaRepository;
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/builder/TestFixtureBuilder.java
+++ b/infra/rdb/pos/src/test/java/com/pos/builder/TestFixtureBuilder.java
@@ -9,6 +9,7 @@ import com.pos.cart.entity.CartEntity;
 import com.pos.menu.entity.MenuCategoryEntity;
 import com.pos.menu.entity.MenuEntity;
 import com.pos.sale.entity.SaleEntity;
+import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 import com.pos.table.entity.TableEntity;
 
@@ -43,5 +44,10 @@ public class TestFixtureBuilder {
 
 	public CartEntity buildCartEntity(CartEntity cartEntity) {
 		return bs.getCartJpaRepository().save(cartEntity);
+	}
+
+	public List<StoreDetailImageEntity> buildStoreDetailImageEntities(
+		List<StoreDetailImageEntity> storeDetailImageEntities) {
+		return bs.getStoreDetailImageJpaRepository().saveAll(storeDetailImageEntities);
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/builder/TestFixtureBuilder.java
+++ b/infra/rdb/pos/src/test/java/com/pos/builder/TestFixtureBuilder.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import com.pos.cart.entity.CartEntity;
 import com.pos.menu.entity.MenuCategoryEntity;
 import com.pos.menu.entity.MenuEntity;
+import com.pos.receipt.entity.ReceiptEntity;
+import com.pos.review.entity.ReviewEntity;
 import com.pos.sale.entity.SaleEntity;
 import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
@@ -49,5 +51,13 @@ public class TestFixtureBuilder {
 	public List<StoreDetailImageEntity> buildStoreDetailImageEntities(
 		List<StoreDetailImageEntity> storeDetailImageEntities) {
 		return bs.getStoreDetailImageJpaRepository().saveAll(storeDetailImageEntities);
+	}
+
+	public ReviewEntity buildReviewEntity(ReviewEntity reviewEntity) {
+		return bs.getReviewJpaRepository().save(reviewEntity);
+	}
+
+	public ReceiptEntity buildReceiptEntity(ReceiptEntity receiptEntity) {
+		return bs.getReceiptJpaRepository().save(receiptEntity);
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/fixtures/review/ReviewEntityFixture.java
+++ b/infra/rdb/pos/src/test/java/com/pos/fixtures/review/ReviewEntityFixture.java
@@ -1,0 +1,34 @@
+package com.pos.fixtures.review;
+
+import com.pos.receipt.entity.ReceiptEntity;
+import com.pos.review.entity.ReviewEntity;
+import com.pos.review.entity.vo.ReviewUser;
+import com.pos.store.entity.StoreEntity;
+
+public class ReviewEntityFixture {
+	// 리뷰 유저 정보
+	private static final Long USER_ID = 1L;
+	private static final Long USER_ID_2 = 2L;
+
+	// 리뷰 유저 닉네임
+	private static final String USER_NICKNAME = "userNickname";
+	private static final String USER_NICKNAME_2 = "userNickname2";
+
+	// 리뷰 내용
+	private static final String REVIEW_CONTENT = "리뷰 내용";
+	private static final String REVIEW_CONTENT_2 = "리뷰 내용2";
+
+	// 리뷰 점수
+	private static final Integer REVIEW_RATTING = 30;
+	private static final Integer REVIEW_RATTING_2 = 20;
+
+	public static ReviewEntity CUSTOM_REVIEW(ReceiptEntity savedReceipt, StoreEntity savedStore) {
+		return ReviewEntity.of(
+			ReviewUser.of(USER_ID, USER_NICKNAME),
+			REVIEW_CONTENT,
+			REVIEW_RATTING,
+			savedStore,
+			savedReceipt
+		);
+	}
+}

--- a/infra/rdb/pos/src/test/java/com/pos/fixtures/store/StoreDetailImageFixture.java
+++ b/infra/rdb/pos/src/test/java/com/pos/fixtures/store/StoreDetailImageFixture.java
@@ -1,0 +1,33 @@
+package com.pos.fixtures.store;
+
+import java.util.List;
+
+import com.pos.store.entity.StoreDetailImageEntity;
+import com.pos.store.entity.StoreEntity;
+
+public class StoreDetailImageFixture {
+	private static final String STORE_DETAIL_IMAGE_URL = "https://pos-api.s3.ap-northeast-2.amazonaws.com/store/2023/10/12/0c4f7a8b-1d5e-4a6b-9f2c-0d1e5f7a8b1c.jpg";
+	private static final String STORE_DETAIL_IMAGE_URL_2 = "https://pos-api.s3.ap-northeast-2.amazonaws.com/store/2023/10/12/0c4f7a8b-1d5e-4a6b-9f2c-0d1e5f7a8b1d.jpg";
+	private static final String STORE_DETAIL_IMAGE_URL_3 = "https://pos-api.s3.ap-northeast-2.amazonaws.com/store/2023/10/12/0c4f7a8b-1d5e-4a6b-9f2c-0d1e5f7a8b1e.jpg";
+	private static final String STORE_DETAIL_IMAGE_URL_4 = "https://pos-api.s3.ap-northeast-2.amazonaws.com/store/2023/10/12/0c4f7a8b-1d5e-4a6b-9f2c-0d1e5f7a8b1f.jpg";
+	private static final String STORE_DETAIL_IMAGE_URL_5 = "https://pos-api.s3.ap-northeast-2.amazonaws.com/store/2023/10/12/0c4f7a8b-1d5e-4a6b-9f2c-0d1e5f7a8b1g.jpg";
+
+	private static final List<String> STORE_DETAIL_IMAGE_URL_LIST = List.of(
+		STORE_DETAIL_IMAGE_URL,
+		STORE_DETAIL_IMAGE_URL_2,
+		STORE_DETAIL_IMAGE_URL_3
+	);
+
+	private static final List<String> STORE_DETAIL_IMAGE_URL_LIST_2 = List.of(
+		STORE_DETAIL_IMAGE_URL_4,
+		STORE_DETAIL_IMAGE_URL_5
+	);
+
+	public static List<StoreDetailImageEntity> CUSTOM_STORE_DETAIL_IMAGES(StoreEntity storeEntity) {
+		return STORE_DETAIL_IMAGE_URL_LIST.stream()
+			.map(url -> StoreDetailImageEntity.of(
+				url,
+				storeEntity
+			)).toList();
+	}
+}

--- a/infra/rdb/pos/src/test/java/com/pos/receipt/ReceiptEntityFixture.java
+++ b/infra/rdb/pos/src/test/java/com/pos/receipt/ReceiptEntityFixture.java
@@ -1,0 +1,33 @@
+package com.pos.receipt;
+
+import java.time.LocalDateTime;
+
+import com.pos.receipt.entity.ReceiptEntity;
+import com.pos.sale.entity.SaleEntity;
+import com.pos.table.entity.TableEntity;
+
+public class ReceiptEntityFixture {
+	// 시작 시간
+	private static final LocalDateTime START_TIME = LocalDateTime.of(2020, 1, 1, 0, 0, 0);
+
+	// 종료 시간
+	private static final LocalDateTime END_TIME = LocalDateTime.of(2020, 1, 1, 1, 0, 0);
+
+	// 사용 요금
+	private static final Integer OCCUPANCY_FEE = 1000;
+
+	// 정산 여부
+	private static final boolean IS_ADJUSTMENT = true;
+
+	public static ReceiptEntity GENERAL_ADJUSTMENT_RECEIPT(SaleEntity saleEntity, TableEntity tableEntity) {
+		return ReceiptEntity.builder()
+			.isAdjustment(IS_ADJUSTMENT)
+			.startUsageTime(START_TIME)
+			.stopUsageTime(END_TIME)
+			.occupancyFee(OCCUPANCY_FEE)
+			.sale(saleEntity)
+			.table(tableEntity)
+			.build();
+	}
+
+}

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -1,13 +1,17 @@
 package com.pos.store.repository;
 
+import static com.pos.fixtures.store.StoreDetailImageFixture.*;
 import static com.pos.fixtures.store.StoreEntityFixture.*;
 import static fixtures.store.StoreFixture.*;
 import static org.assertj.core.api.SoftAssertions.*;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.pos.global.config.RepositoryTest;
+import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 import com.pos.store.mapper.StoreMapper;
 
@@ -114,6 +118,47 @@ class StoreRepositoryImplTest extends RepositoryTest {
 		assertSoftly(softly -> {
 			softly.assertThat(exists).isTrue();
 			softly.assertThat(exists2).isFalse();
+		});
+	}
+
+	@Test
+	void 가게조회_테스트() {
+		// given
+		Store savedStore = GENERAL_CLOSE_STORE();
+		StoreEntity savedStoreEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(savedStore));
+		List<StoreDetailImageEntity> storeDetailImageEntities = testFixtureBuilder.buildStoreDetailImageEntities(
+			CUSTOM_STORE_DETAIL_IMAGES(savedStoreEntity));
+		testEntityManager.flush();
+		testEntityManager.clear();
+
+		// when
+		System.out.println("===StoreRepositoryImplTest.가게조회_테스트 쿼리===");
+		Store store = storeRepository.findStoreByStoreId(savedStoreEntity.getId()).get();
+		System.out.println("===StoreRepositoryImplTest.가게조회_테스트 쿼리===");
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(store.getStoreId()).isEqualTo(savedStoreEntity.getId());
+			softly.assertThat(store.getStoreInfo().getStoreName()).isEqualTo(savedStoreEntity.getName());
+			softly.assertThat(store.getStoreInfo().getLocation().x)
+				.isEqualTo(savedStoreEntity.getLocation().getLatitude());
+			softly.assertThat(store.getStoreInfo().getLocation().y)
+				.isEqualTo(savedStoreEntity.getLocation().getLongitude());
+			softly.assertThat(store.getStoreInfo().getDescription()).isEqualTo(savedStoreEntity.getDescription());
+			softly.assertThat(store.getStoreInfo().getHeadImageUrl()).isEqualTo(savedStoreEntity.getHeadImageUrl());
+			softly.assertThat(store.getStoreInfo().getUniversity()).isEqualTo(savedStoreEntity.getUniversity());
+			softly.assertThat(store.getStoreInfo().getTableCost())
+				.isEqualTo(savedStoreEntity.getTableCostPerTime().getTableCost());
+			softly.assertThat(store.getStoreInfo().getTableTime())
+				.isEqualTo(savedStoreEntity.getTableCostPerTime().getTableTime());
+
+			store.getDetailImageUrls()
+				.forEach(url -> {
+					softly.assertThat(storeDetailImageEntities.stream()
+							.anyMatch(storeDetailImageEntity -> storeDetailImageEntity.getImageUrl().equals(url)))
+						.isTrue();
+				});
+
 		});
 	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -95,4 +95,25 @@ class StoreRepositoryImplTest extends RepositoryTest {
 			softly.assertThat(findStoreEntity.isOpen()).isTrue();
 		});
 	}
+
+	@Test
+	void store_존재여부_테스트() {
+		// given
+		Store savedStore = GENERAL_CLOSE_STORE();
+		StoreEntity savedStoreEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(savedStore));
+		testEntityManager.flush();
+		testEntityManager.clear();
+
+		// when
+		System.out.println("===StoreRepositoryImplTest.store_존재여부_테스트 쿼리===");
+		boolean exists = storeRepository.isExistsById(savedStoreEntity.getId());
+		boolean exists2 = storeRepository.isExistsById(savedStoreEntity.getId() + 1);
+		System.out.println("===StoreRepositoryImplTest.store_존재여부_테스트 쿼리===");
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(exists).isTrue();
+			softly.assertThat(exists2).isFalse();
+		});
+	}
 }

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.pos.store.repository;
 
+import static com.pos.fixtures.sale.SaleFixture.*;
 import static com.pos.fixtures.store.StoreDetailImageFixture.*;
 import static com.pos.fixtures.store.StoreEntityFixture.*;
 import static fixtures.store.StoreFixture.*;
@@ -7,16 +8,28 @@ import static org.assertj.core.api.SoftAssertions.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Slice;
 
+import com.pos.fixtures.review.ReviewEntityFixture;
+import com.pos.fixtures.table.TableEntityFixture;
 import com.pos.global.config.RepositoryTest;
+import com.pos.receipt.ReceiptEntityFixture;
+import com.pos.receipt.entity.ReceiptEntity;
+import com.pos.review.entity.ReviewEntity;
+import com.pos.sale.entity.SaleEntity;
 import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 import com.pos.store.mapper.StoreMapper;
+import com.pos.table.entity.TableEntity;
 
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.entity.dto.StoreHeadDto;
 import domain.pos.store.repository.StoreRepository;
 
 class StoreRepositoryImplTest extends RepositoryTest {
@@ -160,5 +173,53 @@ class StoreRepositoryImplTest extends RepositoryTest {
 				});
 
 		});
+	}
+
+	@Nested
+	@DisplayName("가게 리스트 조회")
+	class StoreListTest {
+		private StoreEntity savedStoreEntity;
+		private TableEntity savedTableEntity;
+		private SaleEntity savedSaleEntity;
+		private ReviewEntity savedReviewEntity;
+		private ReceiptEntity savedReceiptEntity;
+		private List<StoreEntity> savedStoreEntityList;
+
+		@BeforeEach
+		void setUp() {
+			savedStoreEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_OPEN_STORE()));
+			savedTableEntity = testFixtureBuilder.buildTableEntityList(
+				TableEntityFixture.TABLEENTITY_LIST(1, savedStoreEntity)).get(0);
+			savedSaleEntity = testFixtureBuilder.buildSaleEntity(GENERAL_SALE(savedStoreEntity));
+			savedReceiptEntity = testFixtureBuilder.buildReceiptEntity(
+				ReceiptEntityFixture.GENERAL_ADJUSTMENT_RECEIPT(savedSaleEntity, savedTableEntity));
+			savedReviewEntity = testFixtureBuilder.buildReviewEntity(
+				ReviewEntityFixture.CUSTOM_REVIEW(savedReceiptEntity, savedStoreEntity));
+			StoreEntity storeEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_CLOSE_STORE()));
+			savedStoreEntityList = List.of(
+				savedStoreEntity, storeEntity
+			);
+			testEntityManager.flush();
+			testEntityManager.clear();
+		}
+
+		@Test
+		void 가게_리스트_조회_테스트() {
+			Slice<StoreHeadDto> storesCursorOrderByReviewCount = storeRepository.findStoresCursorOrderByReviewCount(
+				null, null, 10);
+
+			assertSoftly(softly -> {
+				softly.assertThat(storesCursorOrderByReviewCount.getContent().size()).isEqualTo(2);
+				for (int i = 0; i < storesCursorOrderByReviewCount.getContent().size(); i++) {
+					StoreHeadDto storeHeadDto = storesCursorOrderByReviewCount.getContent().get(i);
+					softly.assertThat(storeHeadDto.getStoreId()).isEqualTo(savedStoreEntityList.get(i).getId());
+					softly.assertThat(storeHeadDto.getStoreName()).isEqualTo(savedStoreEntityList.get(i).getName());
+					softly.assertThat(storeHeadDto.getIsOpened()).isEqualTo(savedStoreEntityList.get(i).isOpen());
+					softly.assertThat(storeHeadDto.getHeadImageUrl())
+						.isEqualTo(savedStoreEntityList.get(i).getHeadImageUrl());
+				}
+				softly.assertThat(storesCursorOrderByReviewCount.getContent().get(0).getReviewCount()).isEqualTo(1);
+			});
+		}
 	}
 }


### PR DESCRIPTION
## 🍀 작업 사항

### 1️⃣ 기존 리뷰 API 오류 해결

- 리뷰 생성시 storeid를 안받았었는데 받도록 수정
 - 이유 storeId 를 통해서 조회하는 로직이 많아서 성능상 이점이 있다고 판단
- 리뷰 목록 조회를 storeId를 통해 조회하도록 수정

### 2️⃣ store 상세 이미지 url 리스트 추가 및 관련 추가 삭제 api 구현

<img src="https://github.com/user-attachments/assets/d72844d7-c8b3-468f-8551-9692f15ea33b" width="250"/>


- 해당 가게 정보에 가게를 나타내는 이미지가 추가로 존재하기 때문에 추가함

### 3️⃣ 기타 자잘한 수정사항 반영

- 리뷰 상세 조회시 점주 이름 제거

### 4️⃣ 리뷰 개수 내림차순으로 가게 목록을 커서-기반 무한 스크롤(Slice)로 조회 구현

![image](https://github.com/user-attachments/assets/aee72e3a-3de5-40c9-ab66-0e0e00dfe4c8)

- 리뷰 순으로 가게를 나열해야함
- 리뷰 평점 평균 및 리뷰 수 나타내야함
- 가게 상세 이미지 데이터가 포함되어야 함

1. 쿼리 설계

```sql
SELECT  s.id, s.name, s.is_open, s.head_image_url, s.description,
        COUNT(DISTINCT r.id) AS review_cnt,
        AVG(r.rating)        AS rating_avg
FROM    review r
RIGHT JOIN store s ON r.store_id = s.id          -- 리뷰 없는 가게도 포함
GROUP BY s.id
HAVING  (review_cnt <  :cursorCnt)
     OR (review_cnt = :cursorCnt AND s.id < :cursorId)
ORDER  BY review_cnt DESC, s.id DESC
LIMIT   :size + 1                                 -- hasNext 판별용
RIGHT JOIN: 리뷰가 0 개인 가게까지 노출
``` 

집계 필드

COUNT DISTINCT → 리뷰 중복 방지

AVG → NULL 시 0 처리하여 NPE 방지

커서 조건(HAVING)

(리뷰 수, storeId) 복합 커서로 누락·중복 방지

limit + 1 → Slice hasNext 계산



2. N + 1 회피
1️⃣ 헤더 쿼리(위) 로 size + 1개 Store ID 확보 →
2️⃣ 이미지 테이블 WHERE store_id IN (:ids) 한 방 조회 →
3️⃣ Java Map<Long, List<String>> 으로 묶어 DTO에 매핑

쿼리 총 2회이므로 N + 1 미발생.


### ❓ 의논사항


리뷰 개수 내림차순으로 가게 목록을 커서-기반 무한 스크롤(Slice)로 조회에서 최소화하여 2개의 쿼리로 줄이긴 했지만 1개의 쿼리로 가능한지 계속 고민을 했지만 방법이 떠오르지 않았음 좋은 의견있으면 제시해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 가게 상세 이미지 업로드 및 삭제 API가 추가되어, 점주가 가게의 상세 이미지를 등록/삭제할 수 있습니다.
  - 가게 정보 응답에 상세 이미지 URL 목록이 포함됩니다.
  - 리뷰 생성 및 조회 시 가게 ID를 명시적으로 전달하도록 변경되었습니다.
  - 가게 목록 조회에 리뷰 수 기준 커서 페이징 API가 추가되었습니다.

- **개선 사항**
  - 리뷰 조회 API가 영수증 기준에서 가게 기준으로 변경되어, 가게별 최신순 리뷰 목록을 조회할 수 있습니다.
  - 일부 에러 코드의 표기 오류가 수정되었습니다.
  - 가게 존재 여부 및 이미지 존재 여부에 대한 검증 로직이 추가되었습니다.
  - 가게 이미지 관련 저장소 및 서비스 계층이 확장되었습니다.
  - 가게 응답에서 사용자 정보(userId, userNickname)가 제거되었습니다.
  - 일부 메서드가 더 이상 사용되지 않음을 명시(Deprecated)하였습니다.

- **버그 수정**
  - 일부 에러 코드의 표기 오류가 수정되었습니다.

- **테스트**
  - 가게 이미지 등록/삭제, 가게 존재 여부, 리뷰 생성 등 신규 기능 및 예외 상황에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->