### PR TITLE
로컬 개발환경 docker 세팅 및 uuid 랜덤 난수 생성기 성능 트러블 슈팅

### DIFF
--- a/application/gateway/docker-compose/docker-compose.yml
+++ b/application/gateway/docker-compose/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  redis:
+    image: redis:7.2-alpine          # 가볍고 최신(2025-05 기준) 이미지
+    container_name: yabam-gateway-local
+    ports:
+      - "6381:6379"                  # host:container
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data             # 영속화(선택)
+
+volumes:
+  redis-data:

--- a/application/yabam/yabam-core/docker-infra/docker-compose.yml
+++ b/application/yabam/yabam-core/docker-infra/docker-compose.yml
@@ -2,15 +2,16 @@ version: '3.7'
 
 services:
   mysql:
-    image: mysql:latest
+    image: mysql:8.0                # 필요에 따라 버전 조정
     container_name: kumoh_yabam
     ports:
-      - 3315:3306
+      - "3315:3306"                 # 호스트 3315 → 컨테이너 3306
     environment:
-      MYSQL_DATABASE: local_mydb
-      MYSQL_CHARSET: utf8mb4
-      MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_COLLATION: utf8mb4_unicode_ci
+      MYSQL_ROOT_PASSWORD: "1234"   # root 비밀번호
+      MYSQL_DATABASE: "local_mydb"  # 최초 자동 생성될 DB
+      MYSQL_CHARSET: "utf8mb4"
+      MYSQL_COLLATION: "utf8mb4_unicode_ci"
     volumes:
-      - ./data/:/var/lib/mysql
-    restart: always  # 자동 재시작 설정
+      - ./data:/var/lib/mysql
+      - ./docker/mysql/initdb:/docker-entrypoint-initdb.d
+    restart: always

--- a/application/yabam/yabam-core/docker-infra/docker/mysql/initdb/01-create-authdb.sql
+++ b/application/yabam/yabam-core/docker-infra/docker/mysql/initdb/01-create-authdb.sql
@@ -1,0 +1,4 @@
+-- ./docker/mysql/initdb/01-create-authdb.sql
+CREATE DATABASE IF NOT EXISTS `local_authdb`
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;

--- a/utils/util-uuid/src/main/java/com/uuid/UuidUtils.java
+++ b/utils/util-uuid/src/main/java/com/uuid/UuidUtils.java
@@ -1,12 +1,10 @@
 package com.uuid;
 
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class UuidUtils {
-	private static final SecureRandom random = new SecureRandom();
-
 	private UuidUtils() {
 	}
 
@@ -20,12 +18,11 @@ public class UuidUtils {
 
 	public static byte[] randomBytes() {
 		byte[] value = new byte[16];
-		random.nextBytes(value);
+		ThreadLocalRandom.current().nextBytes(value);
 
-		ByteBuffer timestamp = ByteBuffer.allocate(Long.BYTES);
-		timestamp.putLong(System.currentTimeMillis());
-
-		System.arraycopy(timestamp.array(), 2, value, 0, 6);
+		ByteBuffer ts = ByteBuffer.allocate(Long.BYTES)
+			.putLong(System.currentTimeMillis());
+		System.arraycopy(ts.array(), 2, value, 0, 6);
 
 		value[6] = (byte)((value[6] & 0x0F) | 0x70);
 		value[8] = (byte)((value[8] & 0x3F) | 0x80);

--- a/utils/util-uuid/src/test/java/com/uuid/UuidUtilsTest.java
+++ b/utils/util-uuid/src/test/java/com/uuid/UuidUtilsTest.java
@@ -28,4 +28,15 @@ class UuidUtilsTest {
 
 		assertTrue(comparison < 0, "uuid1 should be lexically less than uuid2");
 	}
+
+	@Test
+	void uuid속도_테스트() {
+		long startTime = System.currentTimeMillis();
+		for (int i = 0; i < 1000000000; i++) {
+			UuidUtils.randomV7();
+		}
+		long endTime = System.currentTimeMillis();
+		System.out.println("UUID 생성 시간: " + (endTime - startTime) + "ms");
+		assertTrue((endTime - startTime) < 100000, "UUID generation took too long");
+	}
 }


### PR DESCRIPTION

## 🍀 

### 1️⃣ 로컬 개발환경 docker compose 파일 세팅 완료 했습니다

### 2️⃣ uuid 랜덤 난수 생성시 SecurRandom 성능 문제 해결

기존 난수생성을 SecureRandom 으로 생성했는데, 해당 클래스의 난수 생성에 성능 저하를 나타낸다는 글을 읽고 직접 테스트 하여 개선했습니다

- Test 환경 10억 반복 loop 를 돌려서 uuid 생성 시간을 측정함

- Random() : 약 39 초
![image](https://github.com/user-attachments/assets/3038e68f-73cf-4331-b3a4-ac4cd60106ce)

- SecureRandom: 약 5분 13초
![image](https://github.com/user-attachments/assets/ad0c0c10-487f-4a17-a8a5-7ebbe954ca55)

- ThreadLocalRandom() : 약 18초
![image](https://github.com/user-attachments/assets/86415857-1639-4f28-a2cd-800f916a9d27)

SecureRandom 이 성능 저하를 일으키는 이유는 OS 의 seed를 기준으로 난수를 발생하는데 이 작업이 무거운 작업이라서 그렇다고 합니다.
저희 UUID 는 rdb 엔티티 id 에서 사용하기 때문에 높은 처리량 그리고 추정 불가능만 하면 되기 때문에 엄청 고도화된 보안이 필요 없다고 생각했습니다 그래서 Random을 사용할까 고민하던중에 Random도 내부에서는 락 기반으로 동작하기 때문에 약간의 성능저하가 있길래 가장 성능저하가 덜한 ThreadLocalRandom 를 선택했습니다
따라서 SecureRandom -> ThreadLocalRandom 로 변경했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Redis 서비스를 위한 Docker Compose 설정 파일이 추가되었습니다.
  - MySQL 초기화 스크립트가 추가되어 `local_authdb` 데이터베이스가 생성됩니다.

- **버그 수정**
  - MySQL Docker Compose 설정이 개선되어 명확한 이미지 버전, 포트 매핑, 환경 변수, 볼륨 경로가 적용되었습니다.

- **테스트**
  - UUID 생성 성능을 검증하는 신규 테스트가 추가되었습니다.

- **리팩터링**
  - UUID 생성 로직이 성능 향상을 위해 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->