### PR TITLE
store 목록 조회 및 review 목록 조회 api 오류 해결

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
@@ -78,10 +78,9 @@ public class ReviewController implements ReviewApi {
 	}
 
 	@GetMapping("/api/v1/reviews")
-	@HasRole(userRole = ROLE_ANONYMOUS)
 	public ResponseEntity<ResponseBody<ReviewsCusorResponse>> getReview(
 		@RequestParam Long storeId,
-		@RequestParam Long lastReviewId,
+		@RequestParam(required = false) Long lastReviewId,
 		@RequestParam int size
 	) {
 		return ResponseEntity.ok(createSuccessResponse(

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.application.global.config.swagger.ApiErrorResponseExplanation;
 import com.application.global.config.swagger.ApiResponseExplanations;
 import com.application.global.config.swagger.ApiSuccessResponseExplanation;
-import com.application.presentation.store.dto.request.StoreCursorRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
 import com.application.presentation.store.dto.response.StoreCursorResponse;
 import com.application.presentation.store.dto.response.StoreIdResponse;
@@ -142,8 +141,19 @@ public interface StoreApi {
 	@ApiResponse(content = @Content(
 		mediaType = "application/json",
 		schema = @Schema(implementation = StoreCursorResponse.class)))
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "가게 커서 목록 조회 성공",
+			responseClass = StoreCursorResponse.class
+		)
+	)
 	ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
-		@RequestBody @Valid StoreCursorRequest storeCursorRequest
+		@Schema(description = "마지막 리뷰 수 만약 첫 조회면 null", example = "131")
+		Long lastReviewCount,
+		@Schema(description = "마지막 가게 ID 만약 첫 조회면 null", example = "1")
+		Long lastStoreId,
+		@Schema(description = "가게 개수", example = "10")
+		Integer size
 	);
 
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -6,7 +6,6 @@ import static com.vo.UserRole.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.application.presentation.store.api.StoreApi;
-import com.application.presentation.store.dto.request.StoreCursorRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
 import com.application.presentation.store.dto.response.StoreCursorResponse;
 import com.application.presentation.store.dto.response.StoreIdResponse;
@@ -48,7 +46,6 @@ public class StoreController implements StoreApi {
 	}
 
 	@GetMapping("/api/v1/store")
-	@HasRole(userRole = ROLE_ANONYMOUS)
 	public ResponseEntity<ResponseBody<StoreInfoResponse>> getStoreInfo(
 		@RequestParam @Valid final Long storeId) {
 		return ResponseEntity
@@ -58,14 +55,15 @@ public class StoreController implements StoreApi {
 	}
 
 	@GetMapping("/api/v1/stores")
-	@HasRole(userRole = ROLE_ANONYMOUS)
 	public ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
-		@ModelAttribute @Valid final StoreCursorRequest storeCursorRequest
+		@RequestParam(required = false) Long lastReviewCount,
+		@RequestParam(required = false) Long lastStoreId,
+		@RequestParam Integer size
 	) {
 		return ResponseEntity
 			.ok(createSuccessResponse(StoreCursorResponse.from(
-				storeService.findStores(storeCursorRequest.lastReviewCount(), storeCursorRequest.lastStoreId(),
-					storeCursorRequest.size()))
+				storeService.findStores(lastReviewCount, lastStoreId,
+					size))
 			));
 	}
 

--- a/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/review/repository/dsl/ReviewDslRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import com.pos.review.entity.QReviewEntity;
 import com.pos.review.entity.ReviewEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -34,8 +35,7 @@ public class ReviewDslRepositoryImpl implements ReviewDslRepository {
 	public Slice<ReviewEntity> findReviewsWithUser(Long storeId, Long lastReviewId, int size) {
 		List<ReviewEntity> results = queryFactory
 			.selectFrom(qReviewEntity)
-			.where(qReviewEntity.id.lt(lastReviewId)
-				.and(qReviewEntity.store.id.eq(storeId)))
+			.where(reviewCusorWhereCondition(storeId, lastReviewId))
 			.orderBy(qReviewEntity.id.desc())
 			.limit(size + 1)
 			.fetch();
@@ -45,6 +45,14 @@ public class ReviewDslRepositoryImpl implements ReviewDslRepository {
 		}
 
 		return new SliceImpl<>(results, PageRequest.of(0, size), hasNext);
+	}
+
+	private BooleanExpression reviewCusorWhereCondition(Long storeId, Long lastReviewId) {
+		if (lastReviewId == null) {
+			return qReviewEntity.store.id.eq(storeId);
+		}
+		return qReviewEntity.id.lt(lastReviewId)
+			.and(qReviewEntity.store.id.eq(storeId));
 	}
 
 }


### PR DESCRIPTION

## 🍀 작업 사항


### 1️⃣ store 목록 조회 api 오류 해결

- ModelAttribute 에서 request Param 으로 변경
- swagger 오류 해결

### 2️⃣ review 목록 조회 api 오류 해결 

- review 첫 목록 조회시 lastReviewId 가 null 일 때 고려안해서 생기는 오류 해결

### 📦 관련 이슈

resolves #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 매장 목록 및 리뷰 조회 시, 일부 요청 파라미터(lastReviewId, lastReviewCount, lastStoreId)가 선택적으로 입력 가능하도록 개선되었습니다.
- **버그 수정**
	- 매장 및 리뷰 조회 엔드포인트의 접근 제어가 변경되어, 일부 엔드포인트에서 별도의 권한 없이 접근할 수 있습니다.
- **문서화**
	- 매장 목록 조회 API의 파라미터와 응답 설명이 Swagger 문서에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->