### PR TITLE
기획 변경으로 인한 리뷰 작성 로직 수정 및 store 조회 dsl 에러 수정

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/api/ReviewApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/api/ReviewApi.java
@@ -39,7 +39,6 @@ public interface ReviewApi {
 		),
 		errors = {
 			@ApiErrorResponseExplanation(errorCode = ErrorCode.RECEIPT_NOT_FOUND),
-			@ApiErrorResponseExplanation(errorCode = ErrorCode.REVIEW_NOT_ADJUSTMENT),
 			@ApiErrorResponseExplanation(errorCode = ErrorCode.REVIEW_ALREADY_EXISTS),
 		}
 	)

--- a/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/review/service/ReviewService.java
@@ -31,9 +31,6 @@ public class ReviewService {
 		storeValidator.validateStore(storeId);
 		ReceiptInfo receiptInfo = receiptReader.getReceiptInfo(receiptId)
 			.orElseThrow(() -> new ServiceException(ErrorCode.RECEIPT_NOT_FOUND));
-		if (!receiptInfo.isAdjustment()) {
-			throw new ServiceException(ErrorCode.REVIEW_NOT_ADJUSTMENT);
-		}
 		if (reviewReader.isExistsReview(receiptId, userPassport)) {
 			throw new ServiceException(ErrorCode.REVIEW_ALREADY_EXISTS);
 		}

--- a/domain/domain-pos/src/test/java/domain/pos/review/service/ReviewServiceTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/review/service/ReviewServiceTest.java
@@ -142,37 +142,6 @@ class ReviewServiceTest extends ServiceTest {
 		}
 
 		@Test
-		void 실패_영수증이_정산이_안됨() {
-			// given
-			Receipt savedReceipt = GENERAL_NON_ADJUSTMENT_RECEIPT();
-			ReceiptInfo savedReceiptInfo = savedReceipt.getReceiptInfo();
-			Review responReview = GENERAL_REVIEW(savedReceipt);
-			Long queryStoreId = responReview.getStore().getStoreId();
-			Long queryReceiptId = savedReceipt.getReceiptInfo().getReceiptId();
-			UserPassport queryUserPassport = responReview.getUserPassport();
-			ReviewInfo queryReviewInfo = responReview.getReviewInfo();
-
-			doReturn(Optional.ofNullable(savedReceiptInfo))
-				.when(receiptReader).getReceiptInfo(anyLong());
-
-			// when->then
-			assertSoftly(softly -> {
-				softly.assertThatThrownBy(
-						() -> reviewService.postReview(queryUserPassport, queryStoreId, queryReceiptId, queryReviewInfo))
-					.isInstanceOf(ServiceException.class)
-					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.REVIEW_NOT_ADJUSTMENT);
-				verify(storeValidator)
-					.validateStore(anyLong());
-				verify(receiptReader)
-					.getReceiptInfo(anyLong());
-				verify(reviewReader, never())
-					.isExistsReview(anyLong(), any(UserPassport.class));
-				verify(reviewWriter, never())
-					.postReview(any(UserPassport.class), anyLong(), any(ReceiptInfo.class), any(ReviewInfo.class));
-			});
-		}
-
-		@Test
 		void 실패_이미_영수증이_있음() {
 			// given
 			Receipt savedReceipt = GENERAL_ADJUSTMENT_RECEIPT();

--- a/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
@@ -1,5 +1,8 @@
 package com.pos.store.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -11,9 +14,11 @@ import domain.pos.store.entity.StoreInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -53,6 +58,9 @@ public class StoreEntity extends BaseEntity {
 
 	@Embedded
 	private TableCostPerTime tableCostPerTime;
+
+	@OneToMany(mappedBy = "store", orphanRemoval = false, fetch = FetchType.LAZY)
+	private List<StoreDetailImageEntity> storeDetailImageEntity = new ArrayList<>();
 
 	private StoreEntity(Long ownerId, boolean isOpen, String name, StorePoint location, String description,
 		String headImageUrl, String university, TableCostPerTime tableCostPerTime) {

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -72,4 +72,19 @@ public class StoreMapper {
 			detailImageUrls
 		));
 	}
+
+	public static Optional<Store> toStoreWithStoreDetailImages(StoreEntity storeEntity) {
+		if (storeEntity == null) {
+			return Optional.empty();
+		}
+		return Optional.of(Store.of(
+			storeEntity.getId(),
+			storeEntity.isOpen(),
+			toStoreInfo(storeEntity),
+			UserPassport.of(storeEntity.getId(), null, null),
+			storeEntity.getStoreDetailImageEntity().stream()
+				.map(StoreDetailImageEntity::getImageUrl)
+				.toList()
+		));
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.pos.store.repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Slice;
@@ -42,14 +41,14 @@ public class StoreRepositoryImpl implements StoreRepository {
 
 	@Override
 	public Optional<Store> findStoreByStoreId(Long storeId) {
-		List<StoreDetailImageEntity> storeDetailImageEntities = queryFactory
-			.select(qStoreDetailImageEntity)
-			.from(qStoreDetailImageEntity)
-			.join(qStoreDetailImageEntity.store, qStoreEntity).fetchJoin()
+		StoreEntity storeEntities = queryFactory
+			.select(qStoreEntity)
+			.from(qStoreEntity)
+			.join(qStoreEntity.storeDetailImageEntity, qStoreDetailImageEntity).fetchJoin()
 			.where(qStoreEntity.id.eq(storeId))
-			.fetch();
+			.fetchFirst();
 
-		return StoreMapper.toStore(storeDetailImageEntities);
+		return StoreMapper.toStoreWithStoreDetailImages(storeEntities);
 	}
 
 	@Override


### PR DESCRIPTION

##  🍀 작업사항

### 1️⃣ 기획 변경으로 인한 리뷰 작성 로직 수정

기존
- 정산이 완료되어야만 리뷰 작성 가능

변경 
- 정산이 안되더라도 리뷰 작성 가능

### 2️⃣ store 조회 dsl 에러 수정

기존 
- 상세 이미지가 없으면 store 가 조회 안되는 에러가 있었음

변경
- 상세 이미지가 없어도 조회 가능 -> 에러 해결

resolves #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 매장 엔티티에 상세 이미지 목록 연동이 추가되어, 매장 정보 조회 시 상세 이미지 정보를 함께 제공할 수 있습니다.

- **리팩터**
    - 매장 상세 이미지 조회 로직이 개선되어, 매장 엔티티를 기준으로 상세 이미지와 함께 조회하도록 변경되었습니다.

- **버그 수정**
    - 리뷰 작성 시 영수증의 정산 여부에 대한 제한이 제거되어, 정산되지 않은 영수증으로도 리뷰를 작성할 수 있습니다.

- **테스트**
    - 영수증 정산 상태로 인한 리뷰 작성 실패 테스트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->