### PR TITLE
#65, 66 장바구니 권한 체크 삭제 및 자잘한 수정 

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/call/controller/CallController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/call/controller/CallController.java
@@ -33,8 +33,7 @@ public class CallController implements CallApi {
 	@PostMapping("/api/v1/call")
 	public ResponseEntity<ResponseBody<Void>> postCall(
 		@RequestBody @Valid CallCreateRequest callCreateRequest) {
-		callService.postCall(callCreateRequest.receiptId(), callCreateRequest.storeId(),
-			callCreateRequest.getCallMessage());
+		callService.postCall(callCreateRequest.receiptId(), callCreateRequest.getCallMessage());
 		return ResponseEntity.ok(createSuccessResponse());
 	}
 
@@ -54,7 +53,7 @@ public class CallController implements CallApi {
 	public ResponseEntity<ResponseBody<CallCursorResponse>> getNonCompleteCalls(
 		UserPassport userPassport,
 		@RequestParam Long saleId,
-		@RequestParam Long lastCallId,
+		@RequestParam(required = false) Long lastCallId,
 		@RequestParam Integer size) {
 		return ResponseEntity.ok(createSuccessResponse(
 			CallCursorResponse.from(callService.getNonCompleteCalls(userPassport, saleId, lastCallId, size))));

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/call/dto/request/CallCreateRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/call/dto/request/CallCreateRequest.java
@@ -11,9 +11,6 @@ public record CallCreateRequest(
 	@Schema(description = "영수증 고유 ID", example = "1")
 	@NotNull
 	UUID receiptId,
-	@Schema(description = "가게 고유 ID", example = "1")
-	@NotNull
-	Long storeId,
 	@Schema(description = "직원 호출 메시지", example = "물 주세요")
 	String callMessage
 ) {

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/controller/CartController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/controller/CartController.java
@@ -1,7 +1,6 @@
 package com.application.presentation.cart.controller;
 
 import static com.response.ResponseUtil.*;
-import static com.vo.UserRole.*;
 
 import java.util.UUID;
 
@@ -14,8 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.application.presentation.cart.api.CartApi;
 import com.application.presentation.cart.dto.response.CartInfoResponse;
-import com.authorization.AssignUserPassport;
-import com.authorization.HasRole;
 import com.response.ResponseBody;
 
 import domain.pos.cart.service.CartService;
@@ -28,8 +25,6 @@ public class CartController implements CartApi {
 	private final CartService cartService;
 
 	@PostMapping("/api/v1/cart")
-	@HasRole(userRole = ROLE_USER)
-	@AssignUserPassport
 	public ResponseEntity<ResponseBody<Void>> postCart(
 		@RequestParam final UUID receiptId,
 		@RequestParam final Long menuId,
@@ -39,8 +34,6 @@ public class CartController implements CartApi {
 	}
 
 	@DeleteMapping("/api/v1/cart/menu")
-	@HasRole(userRole = ROLE_USER)
-	@AssignUserPassport
 	public ResponseEntity<ResponseBody<Void>> deleteCart(
 		@RequestParam final UUID receiptId,
 		@RequestParam final Long menuId) {
@@ -49,8 +42,6 @@ public class CartController implements CartApi {
 	}
 
 	@GetMapping("/api/v1/cart")
-	@HasRole(userRole = ROLE_USER)
-	@AssignUserPassport
 	public ResponseEntity<ResponseBody<CartInfoResponse>> getCart(
 		@RequestParam final UUID receiptId) {
 		return ResponseEntity.ok(createSuccessResponse(

--- a/domain/domain-pos/src/main/java/domain/pos/call/service/CallService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/call/service/CallService.java
@@ -26,7 +26,7 @@ public class CallService {
 	private final CallWriter callWriter;
 	private final CallReader callReader;
 
-	public void postCall(final UUID receiptId, final Long storeId, final CallMessage callMessage) {
+	public void postCall(final UUID receiptId, final CallMessage callMessage) {
 		Receipt receipt = receiptReader.getReceiptWithTableAndStore(receiptId)
 			.orElseThrow(() -> {
 				throw new ServiceException(ErrorCode.RECEIPT_NOT_FOUND);
@@ -37,9 +37,7 @@ public class CallService {
 		if (isNonActiveTable(receipt)) {
 			throw new ServiceException(ErrorCode.TABLE_NOT_ACTIVE);
 		}
-		if (!receipt.getSale().getStore().getStoreId().equals(storeId)) {
-			throw new ServiceException(ErrorCode.STORE_NOT_MATCH);
-		}
+
 		callWriter.createCall(receiptId, receipt.getSale().getSaleId(), callMessage);
 
 	}


### PR DESCRIPTION
## 🍀 작업 사항 

### 1️⃣  장바구니 권한 체크 삭제

기존
- 장바구니 유저 권한 체크 

변경 
- 장바구니 유저 권한 체크 삭제

### 2️⃣ 직원 호출 자잘한 수정

- 커서 기반 조회에 커서 id 파라미터 required = false 로 변경
- 직원 호출 생성 로직에 storeId 검증 및 파라미터 삭제

### 관련 이슈

resolves #65 

resolves #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 콜 생성 시 더 이상 매장 ID(storeId)를 입력할 필요가 없습니다.
  - 일부 콜 목록 조회 시 마지막 콜 ID(lastCallId) 파라미터가 선택 사항이 되어 필수 입력 없이 조회할 수 있습니다.

- **기타**
  - 장바구니 관련 기능에서 사용자 역할 및 인증 관련 제한이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->