### PR TITLE
Receipt 리팩토링 및 잡다한 오류 수정

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/api/CartApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/api/CartApi.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.constraints.Min;
 
 @Schema(description = "장바구니 API")
 public interface CartApi {
@@ -35,7 +36,7 @@ public interface CartApi {
 	ResponseEntity<ResponseBody<Void>> postCart(
 		@Schema(description = "영수증 ID", example = "1") @RequestParam final UUID receiptId,
 		@Schema(description = "메뉴 ID", example = "1") @RequestParam final Long menuId,
-		@Schema(description = "수량", example = "2") @RequestParam final Integer quantity);
+		@Schema(description = "수량", example = "2") @RequestParam @Min(value = 1, message = "수량은 최소 1개 이상입니다.") final Integer quantity);
 
 	@Operation(
 		summary = "장바구니 상품 삭제 API",

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/api/CartApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/cart/api/CartApi.java
@@ -36,7 +36,8 @@ public interface CartApi {
 	ResponseEntity<ResponseBody<Void>> postCart(
 		@Schema(description = "영수증 ID", example = "1") @RequestParam final UUID receiptId,
 		@Schema(description = "메뉴 ID", example = "1") @RequestParam final Long menuId,
-		@Schema(description = "수량", example = "2") @RequestParam @Min(value = 1, message = "수량은 최소 1개 이상입니다.") final Integer quantity);
+		@Schema(description = "수량", example = "2")
+		@RequestParam @Min(value = 1, message = "수량은 최소 1개 이상입니다.") final Integer quantity);
 
 	@Operation(
 		summary = "장바구니 상품 삭제 API",

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/api/ReceiptApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/api/ReceiptApi.java
@@ -20,6 +20,7 @@ import com.application.presentation.receipt.dto.response.ReceiptAndOrdersRespons
 import com.application.presentation.receipt.dto.response.ReceiptIdResponse;
 import com.application.presentation.receipt.dto.response.ReceiptInfoResponse;
 import com.application.presentation.receipt.dto.response.ReceiptResponse;
+import com.application.presentation.receipt.dto.response.TableWithReceiptResponse;
 import com.exception.ErrorCode;
 import com.response.ResponseBody;
 import com.vo.UserPassport;
@@ -59,21 +60,42 @@ public interface ReceiptApi {
 
 	@Operation(
 		summary = "영수증 세부정보 조회 API",
-		description = "영수증의 세부정보르 조회합니다."
+		description = "영수증의 세부정보를 조회합니다."
 	)
 	@ApiResponse(content = @Content(
 		mediaType = "application/json",
-		schema = @Schema(implementation = ReceiptInfoResponse.class)))
+		schema = @Schema(implementation = ReceiptAndOrdersResponse.class)))
 	@ApiResponseExplanations(
 		success = @ApiSuccessResponseExplanation(
-			responseClass = ReceiptInfoResponse.class,
+			responseClass = ReceiptAndOrdersResponse.class,
 			description = "영수증 세부정보 조회 성공"
 		),
 		errors = {
 			@ApiErrorResponseExplanation(errorCode = ErrorCode.RECEIPT_NOT_FOUND)
 		}
 	)
-	ResponseEntity<ResponseBody<ReceiptInfoResponse>> getReceiptInfo(@PathVariable UUID receiptId);
+	ResponseEntity<ResponseBody<ReceiptAndOrdersResponse>> getReceiptAndOrdersAndMenus(@PathVariable UUID receiptId);
+
+	@Operation(
+		summary = "매장 전체 테이블 및 미정산 영수증 조회 API",
+		description = "매장 전체 테이블 정보 및 미정산 영수증을 조회합니다."
+	)
+	@ApiResponse(content = @Content(
+		mediaType = "application/json",
+		schema = @Schema(implementation = TableWithReceiptResponse.class)))
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = TableWithReceiptResponse.class,
+			description = "테이블 리스트 및 미정산 영수증 조회 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_SALE),
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_EQUAL_STORE_OWNER)
+		}
+	)
+	ResponseEntity<ResponseBody<TableWithReceiptResponse>> getAllTableNonAdjustReceipts(
+		@Parameter(hidden = true) UserPassport userPassport,
+		@PathVariable Long saleId);
 
 	@Operation(
 		summary = "영업 별 정산 영수증 페이지 조회 API",

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/controller/ReceiptController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/controller/ReceiptController.java
@@ -28,13 +28,14 @@ import com.application.presentation.receipt.dto.response.ReceiptAndOrdersRespons
 import com.application.presentation.receipt.dto.response.ReceiptIdResponse;
 import com.application.presentation.receipt.dto.response.ReceiptInfoResponse;
 import com.application.presentation.receipt.dto.response.ReceiptResponse;
+import com.application.presentation.receipt.dto.response.TableWithReceiptResponse;
 import com.authorization.AssignUserPassport;
 import com.authorization.HasRole;
 import com.response.ResponseBody;
 import com.vo.UserPassport;
 
 import domain.pos.receipt.entity.Receipt;
-import domain.pos.receipt.entity.ReceiptInfo;
+import domain.pos.receipt.entity.TableWithNonAdjustReceipt;
 import domain.pos.receipt.service.ReceiptService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -55,11 +56,24 @@ public class ReceiptController implements ReceiptApi {
 	}
 
 	@GetMapping("/api/v1/receipts/{receiptId}")
-	public ResponseEntity<ResponseBody<ReceiptInfoResponse>> getReceiptInfo(@PathVariable UUID receiptId) {
-		ReceiptInfo receiptInfo = receiptService.getReceiptInfo(receiptId);
-		return ResponseEntity.ok(createSuccessResponse(ReceiptInfoResponse.from(receiptInfo)));
+	public ResponseEntity<ResponseBody<ReceiptAndOrdersResponse>> getReceiptAndOrdersAndMenus(
+		@PathVariable UUID receiptId) {
+		Receipt receipt = receiptService.getReceiptAndOrdersAndMenus(receiptId);
+		return ResponseEntity.ok(createSuccessResponse(ReceiptAndOrdersResponse.from(receipt)));
 	}
 
+	@GetMapping("/api/v1/sales/{saleId}/non-adjust-receipts")
+	@HasRole(userRole = ROLE_OWNER)
+	@AssignUserPassport
+	public ResponseEntity<ResponseBody<TableWithReceiptResponse>> getAllTableNonAdjustReceipts(
+		UserPassport userPassport,
+		@PathVariable Long saleId) {
+		List<TableWithNonAdjustReceipt> tableWithNonAdjustReceipts = receiptService.getAllTableNonAdjustReceipts(
+			userPassport, saleId);
+		return ResponseEntity.ok(createSuccessResponse(TableWithReceiptResponse.from(tableWithNonAdjustReceipts)));
+	}
+
+	// TODO : store 별로 saleId 리스트 조회 로직이 필요해보임
 	@GetMapping("/api/v1/sales/{saleId}/receipts")
 	@HasRole(userRole = ROLE_OWNER)
 	@AssignUserPassport
@@ -121,6 +135,7 @@ public class ReceiptController implements ReceiptApi {
 		return ResponseEntity.ok(createSuccessResponse(ReceiptIdResponse.from(receiptId)));
 	}
 
+	// TODO : 리뷰 작성여부?
 	@GetMapping("/api/v1/customers/{customerId}/receipts")
 	@HasRole(userRole = ROLE_USER)
 	@AssignUserPassport

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/ReceiptAndOrdersResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/ReceiptAndOrdersResponse.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "영수증 및 주문 리스트 응답 DTO")
 public record ReceiptAndOrdersResponse(
-	@Schema(description = "영수증 정보")
+	@Schema(description = "영수증 정보", example = "영수증 정보")
 	ReceiptInfoResponse receiptInfo,
-	@Schema(description = "주문 리스트")
+	@Schema(description = "주문 리스트", example = "주문 리스트")
 	List<OrderAndMenusResponse> orderAndMenusResponses
 ) {
 	public static ReceiptAndOrdersResponse from(Receipt receipt) {

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/ReceiptResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/ReceiptResponse.java
@@ -7,9 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "영수증 응답 DTO")
 public record ReceiptResponse(
-	@Schema(description = "영수증 정보")
+	@Schema(description = "영수증 정보", example = "영수증 정보")
 	ReceiptInfoResponse receiptInfo,
-	@Schema(description = "테이블 정보")
+	@Schema(description = "테이블 정보", example = "테이블 정보")
 	TableInfoResponse.TableInfoDTO tableInfo
 ) {
 	public static ReceiptResponse from(Receipt receipt) {

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/TableWithReceiptResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/TableWithReceiptResponse.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "매장 전체 테이블 및 미정산 영수증 응답 DTO")
 public record TableWithReceiptResponse(
 
-	@Schema(description = "테이블 및 영수증 정보 리스트")
+	@Schema(description = "테이블 및 영수증 정보 리스트", example = "테이블 및 영수증 정보 리스트")
 	List<TableWithReceipt> tableWithReceipts
 ) {
 	public static TableWithReceiptResponse from(List<TableWithNonAdjustReceipt> tableWithNonAdjustReceipts) {
@@ -23,16 +23,16 @@ public record TableWithReceiptResponse(
 	}
 
 	public record TableWithReceipt(
-		@Schema(description = "테이블 id")
+		@Schema(description = "테이블 id", example = "1")
 		Long tableId,
 
-		@Schema(description = "테이블 번호")
+		@Schema(description = "테이블 번호", example = "1")
 		Integer tableNumber,
 
-		@Schema(description = "테이블 활성화 여부(false -> 미정산 영수증을 가지고 있는 상태)")
+		@Schema(description = "테이블 활성화 여부(false -> 미정산 영수증을 가지고 있는 상태)", example = "true")
 		Boolean isActive,
 
-		@Schema(description = "영수증 및 누적 주문 정보")
+		@Schema(description = "영수증 및 누적 주문 정보", example = "영수증 및 누적 주문 정보")
 		ReceiptAndOrders receiptInfo
 	) {
 
@@ -49,10 +49,10 @@ public record TableWithReceiptResponse(
 
 	public record ReceiptAndOrders(
 
-		@Schema(description = "영수증 상세 정보")
+		@Schema(description = "영수증 상세 정보", example = "영수증 상세 정보")
 		ReceiptInfoResponse receiptInfo,
 
-		@Schema(description = "영수증 누적 주문 정보")
+		@Schema(description = "영수증 누적 주문 정보", example = "영수증 누적 주문 정보")
 		List<OrderInfoResponse> orderInfo
 	) {
 

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/TableWithReceiptResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/receipt/dto/response/TableWithReceiptResponse.java
@@ -1,0 +1,68 @@
+package com.application.presentation.receipt.dto.response;
+
+import java.util.List;
+
+import com.application.presentation.order.dto.response.OrderInfoResponse;
+
+import domain.pos.receipt.entity.Receipt;
+import domain.pos.receipt.entity.TableWithNonAdjustReceipt;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "매장 전체 테이블 및 미정산 영수증 응답 DTO")
+public record TableWithReceiptResponse(
+
+	@Schema(description = "테이블 및 영수증 정보 리스트")
+	List<TableWithReceipt> tableWithReceipts
+) {
+	public static TableWithReceiptResponse from(List<TableWithNonAdjustReceipt> tableWithNonAdjustReceipts) {
+		return new TableWithReceiptResponse(
+			tableWithNonAdjustReceipts.stream()
+				.map(TableWithReceipt::from)
+				.toList()
+		);
+	}
+
+	public record TableWithReceipt(
+		@Schema(description = "테이블 id")
+		Long tableId,
+
+		@Schema(description = "테이블 번호")
+		Integer tableNumber,
+
+		@Schema(description = "테이블 활성화 여부(false -> 미정산 영수증을 가지고 있는 상태)")
+		Boolean isActive,
+
+		@Schema(description = "영수증 및 누적 주문 정보")
+		ReceiptAndOrders receiptInfo
+	) {
+
+		public static TableWithReceipt from(TableWithNonAdjustReceipt tableWithNonAdjustReceipt) {
+			return new TableWithReceipt(
+				tableWithNonAdjustReceipt.getTableId(),
+				tableWithNonAdjustReceipt.getTableNumber(),
+				tableWithNonAdjustReceipt.getIsActive(),
+				ReceiptAndOrders.from(tableWithNonAdjustReceipt.getNonAdjustReceipt())
+			);
+		}
+
+	}
+
+	public record ReceiptAndOrders(
+
+		@Schema(description = "영수증 상세 정보")
+		ReceiptInfoResponse receiptInfo,
+
+		@Schema(description = "영수증 누적 주문 정보")
+		List<OrderInfoResponse> orderInfo
+	) {
+
+		public static ReceiptAndOrders from(Receipt nonAdjustReceipt) {
+			if (nonAdjustReceipt == null) {
+				return new ReceiptAndOrders(null, List.of());
+			}
+			return new ReceiptAndOrders(ReceiptInfoResponse.from(nonAdjustReceipt.getReceiptInfo()),
+				nonAdjustReceipt.getOrders().stream().map(OrderInfoResponse::from).toList());
+		}
+
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/cart/entity/CartMenu.java
+++ b/domain/domain-pos/src/main/java/domain/pos/cart/entity/CartMenu.java
@@ -16,4 +16,8 @@ public class CartMenu {
 	public static CartMenu of(Integer quantity, MenuInfo menuInfo) {
 		return new CartMenu(quantity, menuInfo);
 	}
+
+	public void addQuantity(Integer quantity) {
+		this.quantity += quantity;
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/entity/Receipt.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/entity/Receipt.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import domain.pos.order.entity.Order;
+import domain.pos.order.entity.vo.OrderStatus;
 import domain.pos.store.entity.Sale;
 import domain.pos.table.entity.Table;
 import lombok.Getter;
@@ -30,5 +31,9 @@ public class Receipt {
 			sale,
 			table
 		);
+	}
+
+	public void filterCompletedOrders() {
+		this.orders.removeIf(order -> order.getOrderStatus() != OrderStatus.COMPLETED);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/entity/ReceiptInfo.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/entity/ReceiptInfo.java
@@ -30,17 +30,14 @@ public class ReceiptInfo {
 		this.stopUsageTime = LocalDateTime.now();
 
 		long minutesUsed = Duration.between(this.startUsageTime, this.stopUsageTime).toMinutes();
-		Integer costPerMinute = store.getStoreInfo().getTableCost();
+		Integer unitMinutes = store.getStoreInfo().getTableTime();
+		Integer unitCost = store.getStoreInfo().getTableCost();
 
-		this.occupancyFee = (int)(minutesUsed * costPerMinute);
+		int unitCount = (int)Math.ceil((double)minutesUsed / unitMinutes);
+		this.occupancyFee = unitCount * unitCost;
 	}
 
-	public void restart() {
-		this.stopUsageTime = null;
-		this.occupancyFee = null;
-	}
-
-	public void adjust() {
-		this.isAdjustment = true;
+	public void setStartUsageTime(LocalDateTime startUsageTime) {
+		this.startUsageTime = startUsageTime;
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/entity/TableWithNonAdjustReceipt.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/entity/TableWithNonAdjustReceipt.java
@@ -1,0 +1,38 @@
+package domain.pos.receipt.entity;
+
+import java.util.List;
+
+import domain.pos.table.entity.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TableWithNonAdjustReceipt {
+	private final Long tableId;
+	private final Integer tableNumber;
+	private final Boolean isActive;
+	private final Receipt nonAdjustReceipt;
+
+	@Builder
+	public TableWithNonAdjustReceipt(Long tableId, Integer tableNumber, Boolean isActive,
+		Receipt nonAdjustReceipt) {
+		this.tableId = tableId;
+		this.tableNumber = tableNumber;
+		this.isActive = isActive;
+		this.nonAdjustReceipt = nonAdjustReceipt;
+	}
+
+	public static TableWithNonAdjustReceipt of(Table table, List<Receipt> receipts) {
+		Receipt tableReceipt = receipts.stream()
+			.filter(receipt -> receipt.getTable().getTableId().equals(table.getTableId()))
+			.findFirst()
+			.orElse(null);
+		
+		return TableWithNonAdjustReceipt.builder()
+			.tableId(table.getTableId())
+			.tableNumber(table.getTableNumber())
+			.isActive(table.getIsActive())
+			.nonAdjustReceipt(tableReceipt)
+			.build();
+	}
+}

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/entity/TableWithNonAdjustReceipt.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/entity/TableWithNonAdjustReceipt.java
@@ -27,7 +27,6 @@ public class TableWithNonAdjustReceipt {
 			.filter(receipt -> receipt.getTable().getTableId().equals(table.getTableId()))
 			.findFirst()
 			.orElse(null);
-		
 		return TableWithNonAdjustReceipt.builder()
 			.tableId(table.getTableId())
 			.tableNumber(table.getTableNumber())

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/implement/ReceiptReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/implement/ReceiptReader.java
@@ -27,6 +27,10 @@ public class ReceiptReader {
 		return receiptRepository.getReceiptInfo(receiptId);
 	}
 
+	public Optional<Receipt> getReceiptAndOrdersAndMenus(UUID receiptId) {
+		return receiptRepository.getReceiptAndOrdersAndMenus(receiptId);
+	}
+
 	public Optional<Receipt> getReceiptWithTableAndStore(UUID receiptId) {
 		return receiptRepository.getReceiptWithTableAndStore(receiptId);
 	}
@@ -53,6 +57,10 @@ public class ReceiptReader {
 
 	public ReceiptInfo getNonAdjustReceipt(Long tableId) {
 		return receiptRepository.getNonAdjustReceipt(tableId);
+	}
+
+	public List<Receipt> getAllNonAdjustReceiptWithTableAndOrders(Long saleId) {
+		return receiptRepository.getAllNonAdjustReceiptWithTableAndOrders(saleId);
 	}
 
 	public Slice<Receipt> getCustomerReceiptSlice(int pageSize, UUID lastReceiptId, Long customerId) {

--- a/domain/domain-pos/src/main/java/domain/pos/receipt/repository/ReceiptRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/receipt/repository/ReceiptRepository.java
@@ -20,6 +20,8 @@ public interface ReceiptRepository {
 
 	Optional<ReceiptInfo> getReceiptInfo(UUID receiptId);
 
+	Optional<Receipt> getReceiptAndOrdersAndMenus(UUID receiptId);
+
 	Optional<Receipt> getReceiptWithTableAndStore(UUID receiptId);
 
 	List<Receipt> getStopReceiptsWithTableAndStore(List<UUID> receiptIds);
@@ -33,6 +35,8 @@ public interface ReceiptRepository {
 	Page<ReceiptInfo> getAdjustedReceiptPageBySale(Pageable pageable, Long saleId);
 
 	ReceiptInfo getNonAdjustReceipt(Long tableId);
+
+	List<Receipt> getAllNonAdjustReceiptWithTableAndOrders(Long saleId);
 
 	Slice<Receipt> getCustomerReceiptSlice(int pageSize, UUID lastReceiptId, Long customerId);
 

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleValidator.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SaleValidator {
 	public void validateSaleOpen(Sale sale) {
-		if (sale.getCloseDateTime() != null) {
+		if (sale.getCloseDateTime().isPresent()) {
 			log.warn("영업이 이미 종료되었습니다. saleId: {}", sale.getSaleId());
 			throw new ServiceException(ErrorCode.CLOSE_SALE);
 		}

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreValidator.java
@@ -32,6 +32,14 @@ public class StoreValidator {
 		return previousStore;
 	}
 
+	public void validateStoreOwner(UserPassport ownerPassport, Store store) {
+		if (!isEqualSavedStoreOwnerAndQueryOwner(ownerPassport.getUserId(), store)) {
+			log.warn("요청 유저는 Store 소유자와 다름: userId={}, queryStoreId={}", ownerPassport.getUserId(),
+				store.getStoreId());
+			throw new ServiceException(ErrorCode.NOT_EQUAL_STORE_OWNER);
+		}
+	}
+
 	// 가게 소유자와 요청 점주가 같은지 확인
 	private boolean isEqualSavedStoreOwnerAndQueryOwner(Long ownerId, Store previousStore) {
 		return previousStore.getOwnerPassport().getUserId().equals(ownerId);

--- a/infra/rdb/pos/src/main/java/com/pos/cart/repository/impl/CartRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/cart/repository/impl/CartRepositoryImpl.java
@@ -61,8 +61,8 @@ public class CartRepositoryImpl implements CartRepository {
 	public void deleteCartAndCartMenuByReceiptId(UUID receiptId) {
 		CartEntity cartEntity = cartJpaRepository.findCartByReceiptId(receiptId).orElseThrow(
 			() -> new IllegalArgumentException("해당 영수증 id에 해당하는 장바구니 내역이 없습니다." + receiptId));
-		cartJpaRepository.delete(cartEntity);
 		cartMenuJpaRepository.deleteAll(cartEntity.getCartMenus());
 		cartEntity.getCartMenus().clear();
+		cartJpaRepository.delete(cartEntity);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/menu/entity/MenuEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/entity/MenuEntity.java
@@ -66,9 +66,10 @@ public class MenuEntity extends BaseEntity {
 	private MenuCategoryEntity menuCategory;
 
 	@Builder
-	private MenuEntity(Integer order, String name, Integer price, String description, String imageUrl,
+	private MenuEntity(Long id, Integer order, String name, Integer price, String description, String imageUrl,
 		boolean isSoldOut,
 		boolean isRecommended, StoreEntity store, MenuCategoryEntity menuCategory) {
+		this.id = id;
 		this.order = order;
 		this.name = name;
 		this.price = price;
@@ -86,6 +87,7 @@ public class MenuEntity extends BaseEntity {
 
 	public static MenuEntity of(MenuInfo menuInfo, StoreEntity storeEntity, MenuCategoryEntity menuCategoryEntity) {
 		return MenuEntity.builder()
+			.id(menuInfo.getId())
 			.order(menuInfo.getOrder())
 			.name(menuInfo.getName())
 			.price(menuInfo.getPrice())

--- a/infra/rdb/pos/src/main/java/com/pos/menu/mapper/MenuMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/menu/mapper/MenuMapper.java
@@ -12,8 +12,9 @@ import domain.pos.store.entity.Store;
 
 public class MenuMapper {
 	public static MenuEntity toMenuEntity(MenuInfo menuInfo, Store store, MenuCategoryInfo menuCategoryInfo) {
-		return MenuEntity.of(menuInfo, StoreMapper.toStoreEntity(store.getStoreId()),
-			MenuCategoryEntity.from(menuCategoryInfo.getId()));
+		return MenuEntity.of(menuInfo,
+			store == null ? null : StoreMapper.toStoreEntity(store.getStoreId()),
+			menuCategoryInfo == null ? null : MenuCategoryEntity.from(menuCategoryInfo.getId()));
 	}
 
 	public static Menu toMenu(MenuEntity menuEntity, Store store, MenuCategory menuCategory) {

--- a/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/order/repository/impl/OrderRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.pos.order.repository.impl;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,7 +40,8 @@ public class OrderRepositoryImpl implements OrderRepository {
 	public Order postOrderWithCart(Receipt receipt, List<CartMenu> cartMenus) {
 		// 최초 주문 시 영수증 시작시간 기록
 		if (!orderJpaRepository.existsOrderByReceiptId(receipt.getReceiptInfo().getReceiptId())) {
-			receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+			LocalDateTime startTime = receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+			receipt.getReceiptInfo().setStartUsageTime(startTime);
 		}
 
 		// 주문 총 금액 계산
@@ -75,7 +77,8 @@ public class OrderRepositoryImpl implements OrderRepository {
 	public Order postOrderWithoutCart(Receipt receipt, List<OrderMenu> orderMenus) {
 		// 최초 주문 시 영수증 시작시간 기록
 		if (!orderJpaRepository.existsOrderByReceiptId(receipt.getReceiptInfo().getReceiptId())) {
-			receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+			LocalDateTime startTime = receiptJpaRepository.startReceiptUsage(receipt.getReceiptInfo().getReceiptId());
+			receipt.getReceiptInfo().setStartUsageTime(startTime);
 		}
 
 		// 주문 총 금액 계산

--- a/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/receipt/repository/querydsl/ReceiptQueryDslRepository.java
@@ -1,5 +1,6 @@
 package com.pos.receipt.repository.querydsl;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,6 +28,8 @@ public interface ReceiptQueryDslRepository {
 
 	ReceiptEntity findNonAdjustReceipt(Long tableId);
 
+	List<ReceiptEntity> findAllNonAdjustReceiptWithTableAndOrders(Long saleId);
+
 	Slice<ReceiptEntity> findCustomerReceiptSliceWithStore(int pageSize, UUID lastReceiptId, Long customerId);
 
 	Optional<ReceiptEntity> findByIdWithOrders(UUID receiptId);
@@ -35,6 +38,6 @@ public interface ReceiptQueryDslRepository {
 
 	void adjustReceipts(List<Receipt> receipts);
 
-	void startReceiptUsage(UUID receiptId);
+	LocalDateTime startReceiptUsage(UUID receiptId);
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/table/repository/TableRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/table/repository/TableRepositoryImpl.java
@@ -42,6 +42,9 @@ public class TableRepositoryImpl implements TableRepository {
 	@Override
 	public Optional<Table> findByIdWithLock(Long queryTableId, Long storeId) {
 		TableEntity tableEntity = tableJpaRepository.findByIdAndStoreIdForUpdate(queryTableId, storeId);
+		if (tableEntity == null) {
+			return Optional.empty();
+		}
 		return Optional.ofNullable(TableMapper.toTable(tableEntity, tableEntity.getStore().getId()));
 	}
 


### PR DESCRIPTION
🍀 작업 사항
---
### 1️⃣ receipt api 추가 및 변경
- receipt 세부조회 api : receipt의 주문, 주문메뉴 리스트도 응답하도록 변경
- 매장 전체 테이블 및 미정산 영수증 조회 API 구현
- 영수증 사용종료 시 응답하는 주문은 완료된 주문만 응답하도록 변경 (Receipt.filterCompletedOrders())

### 2️⃣ 장바구니 기반 주문 생성 api 수정
- 카트에 동일한 메뉴가 중복되어 있을 때 필터링 로직 추가(OrderWriter.mergeCartMenus())
- 테이블 금액 산정 방법 변경

### 3️⃣ Cart API 자잘한 오류 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 테이블별 미조정 영수증 및 주문 목록을 조회하는 엔드포인트가 추가되었습니다.
    - 영수증 상세 조회 시 주문 및 메뉴 정보까지 함께 제공됩니다.

- **버그 수정**
    - 메뉴 엔터티 생성 시 ID가 누락되는 문제를 수정하였습니다.
    - 메뉴 매핑 시 null 값 처리 로직이 추가되었습니다.

- **개선 및 변경**
    - 장바구니 수량 입력 시 최소 1개 이상이어야 한다는 검증이 추가되었습니다.
    - 주문 생성 시 동일 메뉴의 수량이 자동으로 합산됩니다.
    - 영수증 사용 시작 시간이 주문 시점에 정확히 반영됩니다.
    - 점주 권한 검증 로직이 개선되었습니다.
    - 영수증의 점유 요금 계산 방식이 단위별 요금제로 변경되었습니다.

- **문서화**
    - API 응답 예시와 설명이 Swagger 문서에 추가 및 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->