### PR TITLE
#68 기획 변경으로 인한 리뷰 api deprecate 및 store 목록 조회 정보에 review 제외

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
@@ -32,6 +32,11 @@ import lombok.RequiredArgsConstructor;
 public class ReviewController implements ReviewApi {
 	private final ReviewService reviewService;
 
+	/**
+	 * @deprecated since 2025-05-15
+	 * 기획상 보류.
+	 */
+	@Deprecated(since = "2025-05-15")
 	@PostMapping("/api/v1/review")
 	@HasRole(userRole = ROLE_USER)
 	@AssignUserPassport
@@ -66,6 +71,10 @@ public class ReviewController implements ReviewApi {
 		));
 	}
 
+	/**
+	 * @deprecated since 2025-05-15
+	 * 기획상 보류.
+	 */
 	@DeleteMapping("/api/v1/review")
 	@HasRole(userRole = ROLE_USER)
 	@AssignUserPassport
@@ -77,6 +86,11 @@ public class ReviewController implements ReviewApi {
 		return ResponseEntity.ok(createSuccessResponse());
 	}
 
+	/**
+	 * @deprecated since 2025-05-15
+	 * 기획상 보류.
+	 */
+	@Deprecated(since = "2025-05-15")
 	@GetMapping("/api/v1/reviews")
 	public ResponseEntity<ResponseBody<ReviewsCusorResponse>> getReview(
 		@RequestParam Long storeId,

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/review/controller/ReviewController.java
@@ -75,6 +75,7 @@ public class ReviewController implements ReviewApi {
 	 * @deprecated since 2025-05-15
 	 * 기획상 보류.
 	 */
+	@Deprecated(since = "2025-05-15")
 	@DeleteMapping("/api/v1/review")
 	@HasRole(userRole = ROLE_USER)
 	@AssignUserPassport

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -150,8 +150,6 @@ public interface StoreApi {
 		)
 	)
 	ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
-		@Schema(description = "마지막 리뷰 수 만약 첫 조회면 null", example = "131")
-		Long lastReviewCount,
 		@Schema(description = "마지막 가게 ID 만약 첫 조회면 null", example = "1")
 		Long lastStoreId,
 		@Schema(description = "가게 개수", example = "10")

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -58,13 +58,12 @@ public class StoreController implements StoreApi {
 
 	@GetMapping("/api/v1/stores")
 	public ResponseEntity<ResponseBody<StoreCursorResponse>> getStoreList(
-		@RequestParam(required = false) Long lastReviewCount,
 		@RequestParam(required = false) Long lastStoreId,
 		@RequestParam Integer size
 	) {
 		return ResponseEntity
 			.ok(createSuccessResponse(StoreCursorResponse.from(
-				storeService.findStores(lastReviewCount, lastStoreId,
+				storeService.findStores(lastStoreId,
 					size))
 			));
 	}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/dto/response/StoreCursorResponse.java
@@ -15,8 +15,6 @@ public record StoreCursorResponse(
 	Integer totalCount,
 	@Schema(description = "다음 데이터 존재 여부", example = "true")
 	Boolean hasNextPage,
-	@Schema(description = "마지막 데이터의 review 수", example = "30")
-	Long lastReviewCount,
 	@Schema(description = "마지막 가게 ID", example = "1")
 	Long lastStoreId,
 	@Schema(description = "가게 데이터 리스트", example = "가게 데이터 리스트")
@@ -35,10 +33,6 @@ public record StoreCursorResponse(
 		String headImageUrl,
 		@Schema(description = "가게 설명", example = "가게 설명")
 		String description,
-		@Schema(description = "가게 평균 평점", example = "43")
-		Integer ratingAverage,
-		@Schema(description = "가게 리뷰 수", example = "10")
-		Integer reviewCount,
 		@Schema(description = "가게 상세 이미지 URL 리스트", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
 		List<String> storeDetailImageUrls
 	) {
@@ -49,8 +43,6 @@ public record StoreCursorResponse(
 				.isOpened(storeHeadDto.getIsOpened())
 				.headImageUrl(storeHeadDto.getHeadImageUrl())
 				.description(storeHeadDto.getDescription())
-				.ratingAverage(storeHeadDto.getRatingAverage())
-				.reviewCount(storeHeadDto.getReviewCount())
 				.storeDetailImageUrls(storeHeadDto.getStoreDetailImageUrls())
 				.build();
 		}
@@ -61,8 +53,6 @@ public record StoreCursorResponse(
 		return StoreCursorResponse.builder()
 			.totalCount(size)
 			.hasNextPage(storeHeadDtos.hasNext())
-			.lastReviewCount(storeHeadDtos.getContent().isEmpty() ? null :
-				Long.valueOf(storeHeadDtos.getContent().get(size - 1).getReviewCount()))
 			.lastStoreId(storeHeadDtos.getContent().isEmpty() ? null :
 				storeHeadDtos.getContent().get(size - 1).getStoreId())
 			.storeInfoDtos(storeHeadDtos.getContent().stream()

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/dto/StoreHeadDto.java
@@ -11,25 +11,21 @@ public class StoreHeadDto {
 	private final Boolean isOpened;
 	private final String headImageUrl;
 	private final String description;
-	private final Integer ratingAverage;
-	private final Integer reviewCount;
 	private final List<String> storeDetailImageUrls;
 
 	private StoreHeadDto(Long storeId, String storeName, Boolean isOpened, String headImageUrl, String description,
-		Integer ratingAverage, Integer reviewCount, List<String> storeDetailImageUrls) {
+		List<String> storeDetailImageUrls) {
 		this.storeId = storeId;
 		this.storeName = storeName;
 		this.isOpened = isOpened;
 		this.headImageUrl = headImageUrl;
 		this.description = description;
-		this.ratingAverage = ratingAverage;
-		this.reviewCount = reviewCount;
 		this.storeDetailImageUrls = storeDetailImageUrls != null ? List.copyOf(storeDetailImageUrls) : List.of();
 	}
 
 	public static StoreHeadDto of(Long storeId, String storeName, Boolean isOpened, String headImageUrl,
-		String description, Integer ratingAverage, Integer reviewCount, List<String> storeDetailImageUrls) {
-		return new StoreHeadDto(storeId, storeName, isOpened, headImageUrl, description, ratingAverage, reviewCount,
+		String description, List<String> storeDetailImageUrls) {
+		return new StoreHeadDto(storeId, storeName, isOpened, headImageUrl, description,
 			storeDetailImageUrls);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/StoreReader.java
@@ -22,8 +22,8 @@ public class StoreReader {
 		return storeRepository.findStoreByStoreId(storeId);
 	}
 
-	public Slice<StoreHeadDto> readStores(Long cursorReviewCount, Long cursorStoreId, int size) {
-		return storeRepository.findStoresCursorOrderByReviewCount(cursorReviewCount, cursorStoreId, size);
+	public Slice<StoreHeadDto> readStores(Long lastStoreId, int size) {
+		return storeRepository.findStoresCursorOrderByCreated(lastStoreId, size);
 	}
 
 	public List<Store> readMyStores(UserPassport ownerPassport) {

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/StoreRepository.java
@@ -32,7 +32,7 @@ public interface StoreRepository {
 
 	void deleteDetailImage(Store previousStore, String imageUrl);
 
-	Slice<StoreHeadDto> findStoresCursorOrderByReviewCount(Long cursorReviewCount, Long cursorStoreId, int size);
+	Slice<StoreHeadDto> findStoresCursorOrderByCreated(Long lastStoreId, int size);
 
 	List<Store> findMyStores(Long userId);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -45,9 +45,9 @@ public class StoreService {
 			});
 	}
 
-	public Slice<StoreHeadDto> findStores(final Long cursorReviewCount, final Long cursorId, final int size) {
-		log.info("가게 목록 조회: cursorReviewCount={}, size={}", cursorReviewCount, size);
-		return storeReader.readStores(cursorReviewCount, cursorId, size);
+	public Slice<StoreHeadDto> findStores(final Long lastStoreId, final int size) {
+		log.info("가게 목록 조회: lastStoreId={}, size={}", lastStoreId, size);
+		return storeReader.readStores(lastStoreId, size);
 	}
 
 	public Store updateStoreInfo(

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -10,6 +10,7 @@ import com.vo.UserPassport;
 
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
+import domain.pos.store.entity.dto.StoreHeadDto;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -86,5 +87,18 @@ public class StoreMapper {
 				.map(StoreDetailImageEntity::getImageUrl)
 				.toList()
 		));
+	}
+
+	public static StoreHeadDto toStoreHeadDto(StoreEntity store) {
+		return StoreHeadDto.of(
+			store.getId(),
+			store.getName(),
+			store.isOpen(),
+			store.getHeadImageUrl(),
+			store.getDescription(),
+			store.getStoreDetailImageEntity().stream()
+				.map(StoreDetailImageEntity::getImageUrl)
+				.toList()
+		);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -122,9 +122,10 @@ public class StoreRepositoryImpl implements StoreRepository {
 	}
 
 	@Override
-	public Slice<StoreHeadDto> findStoresCursorOrderByReviewCount(Long cursorReviewCount, Long cursorStoreId,
+	public Slice<StoreHeadDto> findStoresCursorOrderByCreated(
+		Long lastStoreId,
 		int size) {
-		return storeJpaRepository.findStoreHeadsByReviewCountCursor(cursorReviewCount, cursorStoreId, size);
+		return storeJpaRepository.findStoreHeadsByStoreIdCursor(lastStoreId, size);
 	}
 
 	@Override

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Slice;
 import domain.pos.store.entity.dto.StoreHeadDto;
 
 public interface StoreDslRepository {
-	Slice<StoreHeadDto> findStoreHeadsByReviewCountCursor(Long cursorReviewCount,
-		Long cursorStoreId,
+	Slice<StoreHeadDto> findStoreHeadsByStoreIdCursor(
+		Long lastStoreId,
 		int size);
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
@@ -1,8 +1,6 @@
 package com.pos.store.repository.dsl;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -12,7 +10,8 @@ import org.springframework.stereotype.Repository;
 import com.pos.review.entity.QReviewEntity;
 import com.pos.store.entity.QStoreDetailImageEntity;
 import com.pos.store.entity.QStoreEntity;
-import com.querydsl.core.Tuple;
+import com.pos.store.entity.StoreEntity;
+import com.pos.store.mapper.StoreMapper;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -30,82 +29,32 @@ public class StoreDslRepositoryImpl implements StoreDslRepository {
 	private final QStoreDetailImageEntity storeDetailImage = QStoreDetailImageEntity.storeDetailImageEntity;
 
 	@Override
-	public Slice<StoreHeadDto> findStoreHeadsByReviewCountCursor(
-		Long cursorReviewCnt, Long cursorStoreId, int size) {
-		List<Tuple> results = queryFactory
-			.select(
-				store.id,
-				store.name,
-				store.isOpen,
-				store.headImageUrl,
-				store.description,
-				review.id.countDistinct(),
-				review.rating.avg()
-			)
-			.from(review)
-			.rightJoin(review.store, store)
-			.groupBy(store.id)
-			.having(cursorReviewCountOrCursorStoreIdLt(cursorReviewCnt, cursorStoreId))
-			.orderBy(review.id.countDistinct().desc(), store.id.desc())
+	public Slice<StoreHeadDto> findStoreHeadsByStoreIdCursor(
+		Long lastStoreId, int size) {
+		List<StoreEntity> result = queryFactory
+			.select(store)
+			.from(store)
+			.leftJoin(store.storeDetailImageEntity, storeDetailImage).fetchJoin()
+			.where(cursorCondition(lastStoreId))
+			.orderBy(store.id.desc())
 			.limit(size + 1)
 			.fetch();
-		return tupleToStoreHeadDto(results, size);
-	}
-
-	private BooleanExpression cursorReviewCountOrCursorStoreIdLt(Long cursorReviewCnt, Long cursorStoreId) {
-		if (cursorReviewCnt == null || cursorStoreId == null) {
-			return null;
-		}
-		return review.id.countDistinct().lt(cursorReviewCnt)
-			.or(review.id.countDistinct().eq(cursorReviewCnt)
-				.and(store.id.lt(cursorStoreId)));
-	}
-
-	private Slice<StoreHeadDto> tupleToStoreHeadDto(List<Tuple> results, int size) {
-		boolean hasNext = results.size() > size;
+		boolean hasNext = result.size() > size;
 		if (hasNext) {
-			results.remove(size);
+			result.remove(size);
 		}
-		List<Long> storeIds = results.stream()
-			.map(t -> t.get(store.id))
-			.toList();
-
-		if (storeIds.isEmpty()) {
-			return new SliceImpl<>(List.of(), PageRequest.of(0, size), hasNext);
-		}
-		Map<Long, List<String>> imageUrlMap = getStoreImageUrlsByStoreIds(storeIds);
-
-		List<StoreHeadDto> list = results.stream()
-			.map(tuple -> {
-				int ratingAvg = tuple.get(review.rating.avg()) == null ? 0 : tuple.get(review.rating.avg()).intValue();
-				return StoreHeadDto.of(
-					tuple.get(store.id),
-					tuple.get(store.name),
-					tuple.get(store.isOpen),
-					tuple.get(store.headImageUrl),
-					tuple.get(store.description),
-					ratingAvg,
-					tuple.get(review.id.countDistinct()).intValue(),
-					imageUrlMap.get(tuple.get(store.id)) == null
-						? List.of()
-						: imageUrlMap.get(tuple.get(store.id))
-				);
-			})
+		List<StoreHeadDto> list = result.stream()
+			.map(StoreMapper::toStoreHeadDto)
 			.toList();
 		return new SliceImpl<>(list, PageRequest.of(0, size), hasNext);
 
 	}
 
-	private Map<Long, List<String>> getStoreImageUrlsByStoreIds(List<Long> storeIds) {
-		return queryFactory
-			.select(storeDetailImage.store.id, storeDetailImage.imageUrl)
-			.from(storeDetailImage)
-			.where(storeDetailImage.store.id.in(storeIds))
-			.fetch()
-			.stream()
-			.collect(Collectors.groupingBy(
-				t -> t.get(storeDetailImage.store.id),
-				Collectors.mapping(t -> t.get(storeDetailImage.imageUrl), Collectors.toList())
-			));
+	private BooleanExpression cursorCondition(Long lastStoreId) {
+		if (lastStoreId == null) {
+			return null;
+		}
+		return store.id.lt(lastStoreId);
 	}
+
 }

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -15,12 +15,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Slice;
 
-import com.pos.fixtures.review.ReviewEntityFixture;
 import com.pos.fixtures.table.TableEntityFixture;
 import com.pos.global.config.RepositoryTest;
 import com.pos.receipt.ReceiptEntityFixture;
 import com.pos.receipt.entity.ReceiptEntity;
-import com.pos.review.entity.ReviewEntity;
 import com.pos.sale.entity.SaleEntity;
 import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
@@ -213,7 +211,6 @@ class StoreRepositoryImplTest extends RepositoryTest {
 		private StoreEntity savedStoreEntity;
 		private TableEntity savedTableEntity;
 		private SaleEntity savedSaleEntity;
-		private ReviewEntity savedReviewEntity;
 		private ReceiptEntity savedReceiptEntity;
 		private List<StoreEntity> savedStoreEntityList;
 
@@ -225,11 +222,9 @@ class StoreRepositoryImplTest extends RepositoryTest {
 			savedSaleEntity = testFixtureBuilder.buildSaleEntity(GENERAL_SALE(savedStoreEntity));
 			savedReceiptEntity = testFixtureBuilder.buildReceiptEntity(
 				ReceiptEntityFixture.GENERAL_ADJUSTMENT_RECEIPT(savedSaleEntity, savedTableEntity));
-			savedReviewEntity = testFixtureBuilder.buildReviewEntity(
-				ReviewEntityFixture.CUSTOM_REVIEW(savedReceiptEntity, savedStoreEntity));
 			StoreEntity storeEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_CLOSE_STORE()));
 			savedStoreEntityList = List.of(
-				savedStoreEntity, storeEntity
+				storeEntity, savedStoreEntity
 			);
 			testEntityManager.flush();
 			testEntityManager.clear();
@@ -237,8 +232,10 @@ class StoreRepositoryImplTest extends RepositoryTest {
 
 		@Test
 		void 가게_리스트_조회_테스트() {
-			Slice<StoreHeadDto> storesCursorOrderByReviewCount = storeRepository.findStoresCursorOrderByReviewCount(
-				null, null, 10);
+			System.out.println("===StoreRepositoryImplTest.가게_리스트_조회_테스트 쿼리===");
+			Slice<StoreHeadDto> storesCursorOrderByReviewCount = storeRepository.findStoresCursorOrderByCreated(
+				null, 10);
+			System.out.println("===StoreRepositoryImplTest.가게_리스트_조회_테스트 쿼리===");
 
 			assertSoftly(softly -> {
 				softly.assertThat(storesCursorOrderByReviewCount.getContent().size()).isEqualTo(2);
@@ -250,7 +247,6 @@ class StoreRepositoryImplTest extends RepositoryTest {
 					softly.assertThat(storeHeadDto.getHeadImageUrl())
 						.isEqualTo(savedStoreEntityList.get(i).getHeadImageUrl());
 				}
-				softly.assertThat(storesCursorOrderByReviewCount.getContent().get(0).getReviewCount()).isEqualTo(1);
 			});
 		}
 	}


### PR DESCRIPTION
## 🍀 작업 사항

### 1️⃣ 기획 변경으로 인해 리뷰 api deprecated


### 2️⃣ store 목록 조회 데이터 변경 및 정렬 기준 변경

기존 
- 리뷰 수 및 리뷰 평균이 있었음
- 정렬 기준이 리뷰 수 기준 내림차순

변경
- 리뷰수 리뷰 평균 제거
- 정렬 기준 storeId 기준 내림차순
 - 해당 기준은 추후 변경될 예정 

### 관련 이슈
resolves #68 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 일부 리뷰 관련 기능이 더 이상 사용되지 않음을 알리는 안내가 추가되었습니다.

- **Refactor**
    - 가게 목록 조회 시 정렬 및 페이징 방식이 리뷰 수 기준에서 생성일 기준으로 변경되었습니다.
    - 가게 정보에서 평점 및 리뷰 수 관련 항목이 제거되었습니다.
    - API 파라미터와 응답 구조가 간소화되었습니다.

- **Tests**
    - 리뷰 관련 테스트 데이터 및 검증이 제거되고, 생성일 기준 정렬 테스트로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->