### PR TITLE
판매 내역 커서 조회 개발

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/api/SaleApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/api/SaleApi.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.application.global.config.swagger.ApiErrorResponseExplanation;
 import com.application.global.config.swagger.ApiResponseExplanations;
 import com.application.global.config.swagger.ApiSuccessResponseExplanation;
+import com.application.presentation.sale.dto.response.SaleCursorResponse;
 import com.application.presentation.sale.dto.response.SaleIdResponse;
 import com.exception.ErrorCode;
 import com.response.ResponseBody;
@@ -61,5 +62,27 @@ public interface SaleApi {
 	ResponseEntity<ResponseBody<Void>> closeStore(
 		@Parameter(hidden = true) UserPassport userPassport,
 		@Schema(description = "가게 고유 ID", example = "1") @RequestParam Long storeId
+	);
+
+	@Operation(
+		summary = "판매 내역 조회",
+		description = "판매 내역을 조회합니다."
+	)
+	@ApiResponse(content = @Content(
+		mediaType = "application/json",
+		schema = @Schema(implementation = SaleCursorResponse.class)))
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			responseClass = SaleCursorResponse.class,
+			description = "판매 내역 조회 성공"
+		)
+	)
+	ResponseEntity<ResponseBody<SaleCursorResponse>> getSales(
+		@Schema(description = "가게 고유 ID", example = "1")
+		@RequestParam Long storeId,
+		@Schema(description = "마지막 판매 ID", example = "1")
+		@RequestParam(required = false) Long lastSaleId,
+		@Schema(description = "가져올 데이터 수", example = "10")
+		@RequestParam Integer size
 	);
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/controller/SaleController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/controller/SaleController.java
@@ -4,12 +4,14 @@ import static com.response.ResponseUtil.*;
 import static com.vo.UserRole.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.application.presentation.sale.api.SaleApi;
+import com.application.presentation.sale.dto.response.SaleCursorResponse;
 import com.application.presentation.sale.dto.response.SaleIdResponse;
 import com.authorization.AssignUserPassport;
 import com.authorization.HasRole;
@@ -46,6 +48,19 @@ public class SaleController implements SaleApi {
 	) {
 		saleService.closeStore(userPassport, storeId);
 		return ResponseEntity.ok(createSuccessResponse());
+	}
+
+	@GetMapping("/api/v1/sales")
+	@HasRole(userRole = ROLE_OWNER)
+	public ResponseEntity<ResponseBody<SaleCursorResponse>> getSales(
+		@RequestParam Long storeId,
+		@RequestParam(required = false) Long lastSaleId,
+		@RequestParam Integer size
+	) {
+		return ResponseEntity.ok(createSuccessResponse(
+				SaleCursorResponse.from(saleService.getSingleSalesByStore(storeId, lastSaleId, size))
+			)
+		);
 	}
 
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/dto/response/SaleCursorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/dto/response/SaleCursorResponse.java
@@ -56,7 +56,7 @@ public record SaleCursorResponse(
 				.saleId(sale.getSaleId())
 				.openDateTime(sale.getOpenDateTime())
 				.closeDateTime(sale.getCloseDateTime().orElse(null))
-				.isOpen(sale.getCloseDateTime().get() == null ? true : false)
+				.isOpen(sale.getCloseDateTime().isEmpty())
 				.build();
 		}
 	}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/dto/response/SaleCursorResponse.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/sale/dto/response/SaleCursorResponse.java
@@ -1,0 +1,64 @@
+package com.application.presentation.sale.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import domain.pos.store.entity.Sale;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(name = "SaleCursorResponse", description = "영업 커서 응답")
+@Builder
+public record SaleCursorResponse(
+	@Schema(description = "데이터 수", example = "10")
+	Integer totalCount,
+	@Schema(description = "다음 데이터 존재 여부", example = "true")
+	Boolean hasNextPage,
+	@Schema(description = "마지막 영업 ID", example = "1")
+	Long lastSaleId,
+	@Schema(description = "영업 데이터 리스트", example = "영업 데이터 리스트")
+	List<SaleInfoDto> saleInfoDtos
+) {
+	public static SaleCursorResponse from(Slice<Sale> saleSlice) {
+		List<SaleInfoDto> saleInfoDtos = saleSlice.getContent().stream()
+			.map(SaleInfoDto::from)
+			.toList();
+		return SaleCursorResponse.builder()
+			.totalCount(saleSlice.getNumberOfElements())
+			.hasNextPage(saleSlice.hasNext())
+			.lastSaleId(saleSlice.getContent().isEmpty() ? null :
+				saleSlice.getContent().get(saleSlice.getNumberOfElements() - 1).getSaleId())
+			.saleInfoDtos(saleInfoDtos)
+			.build();
+	}
+
+	@Schema(name = "SaleInfoDto", description = "영업 데이터")
+	@Builder
+	public record SaleInfoDto(
+		@Schema(description = "영업 ID", example = "1")
+		Long saleId,
+		@Schema(description = "영업 시작 시간", example = "2023-10-01T10:00:00")
+		@JsonSerialize(using = LocalDateTimeSerializer.class)
+		LocalDateTime openDateTime,
+		@Schema(description = "영업 종료 시간", example = "2023-10-01T18:00:00")
+		@JsonSerialize(using = LocalDateTimeSerializer.class)
+		LocalDateTime closeDateTime,
+		@Schema(description = "가게 오픈 여부", example = "true")
+		Boolean isOpen
+	) {
+		public static SaleInfoDto from(Sale sale) {
+			return SaleInfoDto.builder()
+				.saleId(sale.getSaleId())
+				.openDateTime(sale.getOpenDateTime())
+				.closeDateTime(sale.getCloseDateTime().orElse(null))
+				.isOpen(sale.getCloseDateTime().get() == null ? true : false)
+				.build();
+		}
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleReader.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/implement/SaleReader.java
@@ -2,6 +2,7 @@ package domain.pos.store.implement;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import domain.pos.store.entity.Sale;
@@ -21,4 +22,7 @@ public class SaleReader {
 		return saleRepository.getOpenSaleByStoreId(storeId);
 	}
 
+	public Slice<Sale> getSingleSalesByStore(Long storeId, Long lastSaleId, int size) {
+		return saleRepository.getSaleSliceByStoreId(storeId, lastSaleId, size);
+	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/repository/SaleRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/repository/SaleRepository.java
@@ -2,6 +2,7 @@ package domain.pos.store.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import domain.pos.store.entity.Sale;
@@ -16,4 +17,6 @@ public interface SaleRepository {
 	Optional<Sale> getOpenSaleByStoreId(Long storeId);
 
 	Sale closeSale(Sale savedSale, Store closeStore);
+
+	Slice<Sale> getSaleSliceByStoreId(Long storeId, Long lastSaleId, int size);
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/SaleService.java
@@ -1,5 +1,6 @@
 package domain.pos.store.service;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,6 +72,10 @@ public class SaleService {
 				savedSale.getStore().getStoreId());
 			throw new ServiceException(ErrorCode.CONFLICT_CLOSE_STORE);
 		}
+	}
+
+	public Slice<Sale> getSingleSalesByStore(final Long storeId, final Long lastSaleId, final int size) {
+		return saleReader.getSingleSalesByStore(storeId, lastSaleId, size);
 	}
 
 }

--- a/infra/rdb/pos/src/main/java/com/pos/sale/mapper/SaleMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/sale/mapper/SaleMapper.java
@@ -26,6 +26,15 @@ public class SaleMapper {
 			previousStore);
 	}
 
+	public static Sale toSale(SaleEntity saleEntity) {
+		return Sale.of(
+			saleEntity.getId(),
+			saleEntity.getOpenDateTime(),
+			saleEntity.getCloseDateTime(),
+			null
+		);
+	}
+
 	public static Sale toSaleWithStore(SaleEntity saleEntity) {
 		if (saleEntity == null) {
 			return null;

--- a/infra/rdb/pos/src/test/java/com/pos/sale/repository/SaleRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/sale/repository/SaleRepositoryImplTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Slice;
 
 import com.pos.fixtures.sale.SaleFixture;
 import com.pos.global.config.RepositoryTest;
@@ -100,6 +101,30 @@ class SaleRepositoryImplTest extends RepositoryTest {
 				.isEqualTo(savedStore.getOwnerPassport().getUserId());
 			softly.assertThat(sale.getOpenDateTime()).isNotNull();
 			softly.assertThat(sale.getCloseDateTime()).isNotEmpty();
+		});
+	}
+
+	@Test
+	void SaleCusor_리스트_조회_테스트() {
+		// given
+		SaleEntity saleEntity = testFixtureBuilder.buildSaleEntity(SaleFixture.GENERAL_SALE(savedStoreEntity));
+		SaleEntity saleEntity2 = testFixtureBuilder.buildSaleEntity(SaleFixture.GENERAL_SALE(savedStoreEntity));
+		SaleEntity saleEntity3 = testFixtureBuilder.buildSaleEntity(SaleFixture.GENERAL_SALE(savedStoreEntity));
+		testEntityManager.flush();
+		testEntityManager.clear();
+
+		// when
+		System.out.println("===SaleRepositoryImplTest.SaleCusor_리스트_조회 쿼리===");
+		Slice<Sale> resultSale = saleRepository.getSaleSliceByStoreId(savedStore.getStoreId(), null, 3);
+		System.out.println("===SaleRepositoryImplTest.SaleCusor_리스트_조회 쿼리===");
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(resultSale.getContent().size()).isEqualTo(3);
+			softly.assertThat(resultSale.hasNext()).isFalse();
+			softly.assertThat(resultSale.getContent().get(0).getSaleId()).isEqualTo(saleEntity3.getId());
+			softly.assertThat(resultSale.getContent().get(1).getSaleId()).isEqualTo(saleEntity2.getId());
+			softly.assertThat(resultSale.getContent().get(2).getSaleId()).isEqualTo(saleEntity.getId());
 		});
 	}
 

--- a/infra/rdb/pos/src/test/java/com/pos/sale/repository/SaleRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/sale/repository/SaleRepositoryImplTest.java
@@ -105,7 +105,7 @@ class SaleRepositoryImplTest extends RepositoryTest {
 	}
 
 	@Test
-	void SaleCusor_리스트_조회_테스트() {
+	void SaleCursor_리스트_조회_테스트() {
 		// given
 		SaleEntity saleEntity = testFixtureBuilder.buildSaleEntity(SaleFixture.GENERAL_SALE(savedStoreEntity));
 		SaleEntity saleEntity2 = testFixtureBuilder.buildSaleEntity(SaleFixture.GENERAL_SALE(savedStoreEntity));
@@ -114,9 +114,9 @@ class SaleRepositoryImplTest extends RepositoryTest {
 		testEntityManager.clear();
 
 		// when
-		System.out.println("===SaleRepositoryImplTest.SaleCusor_리스트_조회 쿼리===");
+		System.out.println("===SaleRepositoryImplTest.SaleCursor_리스트_조회 쿼리===");
 		Slice<Sale> resultSale = saleRepository.getSaleSliceByStoreId(savedStore.getStoreId(), null, 3);
-		System.out.println("===SaleRepositoryImplTest.SaleCusor_리스트_조회 쿼리===");
+		System.out.println("===SaleRepositoryImplTest.SaleCursor_리스트_조회 쿼리===");
 
 		// then
 		assertSoftly(softly -> {


### PR DESCRIPTION
### 1️⃣ 작업 사항 

특정 가게의 역대 판매 내역을 조회하는 api 개발

- 응답 데이터
  - totalCount: 현재 페이지의 데이터 수
  - hasNextPage: 다음 페이지 존재 여부
  - lastSaleId: 마지막 영업 ID (커서 기반 페이지네이션에 사용됨)
  - saleInfoDtos: 영업 데이터 리스트
  - saleId: 영업 ID
  - openDateTime: 영업 시작 시간
  - closeDateTime: 영업 종료 시간 (종료되지 않았을 경우 null)
  - isOpen: 영업 중 여부 (closeDateTime이 null이면 true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 매장별 판매 내역을 커서 기반 페이지네이션 방식으로 조회할 수 있는 새로운 API가 추가되었습니다. 사용자는 매장 ID, 마지막 판매 ID(선택), 조회 개수를 지정하여 판매 이력을 조회할 수 있습니다.
- **문서화**
    - API 명세에 판매 내역 조회 엔드포인트가 추가되어, 요청 및 응답 구조가 명확하게 안내됩니다.
- **테스트**
    - 판매 내역 커서 조회 기능에 대한 테스트가 추가되어, 올바른 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->