### PR TITLE
 image url store 대표 이미지 상세 이미지 메뉴 이미지 공통 presignedUrl api 로 리팩터링

### DIFF
--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/image/api/ImageApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/image/api/ImageApi.java
@@ -1,0 +1,35 @@
+package com.application.presentation.image.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.application.global.config.swagger.ApiErrorResponseExplanation;
+import com.application.global.config.swagger.ApiResponseExplanations;
+import com.application.global.config.swagger.ApiSuccessResponseExplanation;
+import com.application.presentation.image.dto.request.PresignedUrlRequest;
+import com.exception.ErrorCode;
+import com.response.ResponseBody;
+import com.vo.UserPassport;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+
+public interface ImageApi {
+	@Operation(
+		summary = "가게 관련 데이터 이미지 조회용 Presigned URL 발급 API",
+		description = "가게 ID와 이미지 프로퍼티를 전달받아, S3 접근을 위한 Presigned URL을 발급합니다."
+	)
+	@ApiResponseExplanations(
+		success = @ApiSuccessResponseExplanation(
+			description = "Presigned URL 발급 성공"
+		),
+		errors = {
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_STORE),
+			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_EQUAL_STORE_OWNER)
+		}
+	)
+	ResponseEntity<ResponseBody<String>> getPresignedUrl(
+		@Parameter(hidden = true) UserPassport userPassport,
+		@RequestBody @Valid PresignedUrlRequest presignedUrlRequest);
+}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/image/controller/ImageController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/image/controller/ImageController.java
@@ -1,0 +1,38 @@
+package com.application.presentation.image.controller;
+
+import static com.response.ResponseUtil.*;
+import static com.vo.UserRole.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.application.presentation.image.api.ImageApi;
+import com.application.presentation.image.dto.request.PresignedUrlRequest;
+import com.authorization.AssignUserPassport;
+import com.authorization.HasRole;
+import com.response.ResponseBody;
+import com.vo.UserPassport;
+
+import domain.pos.image.service.ImageService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController implements ImageApi {
+	private final ImageService imageService;
+
+	@PostMapping("/api/v1/presigned-url")
+	@HasRole(userRole = ROLE_OWNER)
+	@AssignUserPassport
+	public ResponseEntity<ResponseBody<String>> getPresignedUrl(
+		UserPassport userPassport,
+		@RequestBody @Valid PresignedUrlRequest presignedUrlRequest) {
+		return ResponseEntity
+			.ok(createSuccessResponse(
+				imageService.getPresignedUrl(userPassport, presignedUrlRequest.storeId(),
+					presignedUrlRequest.imageProperty())));
+	}
+}

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/image/dto/request/PresignedUrlRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/image/dto/request/PresignedUrlRequest.java
@@ -1,20 +1,20 @@
-package com.application.presentation.store.dto.request;
+package com.application.presentation.image.dto.request;
 
 import com.application.global.validator.ValidEnum;
 
-import domain.pos.store.entity.vo.StoreImageProperty;
+import domain.pos.image.entity.ImageProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "StorePresignedUrlRequest", description = "스토어 프리사인드 URL 요청")
-public record StorePresignedUrlRequest(
+public record PresignedUrlRequest(
 	@Schema(description = "스토어 ID", example = "1")
 	@NotNull
 	@Min(value = 1, message = "스토어 ID는 1 이상이어야 합니다.")
 	Long storeId,
 	@Schema(description = "스토어 이미지 속성", example = "STORE_HEAD")
-	@ValidEnum(message = "스토어 이미지 속성은 STORE_HEAD, STORE_DETAIL 중 하나여야 합니다.", enumClass = StoreImageProperty.class)
-	StoreImageProperty storeImageProperty
+	@ValidEnum(message = "스토어 이미지 속성은 STORE_HEAD, STORE_DETAIL 중 하나여야 합니다.", enumClass = ImageProperty.class)
+	ImageProperty imageProperty
 ) {
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/image/dto/request/PresignedUrlRequest.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/image/dto/request/PresignedUrlRequest.java
@@ -7,14 +7,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(name = "StorePresignedUrlRequest", description = "스토어 프리사인드 URL 요청")
+@Schema(name = "PresignedUrlRequest", description = "스토어 프리사인드 URL 요청")
 public record PresignedUrlRequest(
 	@Schema(description = "스토어 ID", example = "1")
 	@NotNull
 	@Min(value = 1, message = "스토어 ID는 1 이상이어야 합니다.")
 	Long storeId,
 	@Schema(description = "스토어 이미지 속성", example = "STORE_HEAD")
-	@ValidEnum(message = "스토어 이미지 속성은 STORE_HEAD, STORE_DETAIL 중 하나여야 합니다.", enumClass = ImageProperty.class)
+	@ValidEnum(message = "스토어 이미지 속성은 STORE_HEAD, STORE_DETAIL, MENU_IMAGE 중 하나여야 합니다.",
+		enumClass = ImageProperty.class)
 	ImageProperty imageProperty
 ) {
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/api/StoreApi.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.application.global.config.swagger.ApiErrorResponseExplanation;
 import com.application.global.config.swagger.ApiResponseExplanations;
 import com.application.global.config.swagger.ApiSuccessResponseExplanation;
-import com.application.presentation.store.dto.request.StorePresignedUrlRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
 import com.application.presentation.store.dto.response.MyStoreResopnse;
 import com.application.presentation.store.dto.response.StoreCursorResponse;
@@ -172,22 +171,5 @@ public interface StoreApi {
 	ResponseEntity<ResponseBody<MyStoreResopnse>> getMyStoreList(
 		@Parameter(hidden = true) UserPassport userPassport
 	);
-
-	@Operation(
-		summary = "가게 이미지 조회용 Presigned URL 발급 API",
-		description = "가게 ID와 이미지 프로퍼티를 전달받아, S3 접근을 위한 Presigned URL을 발급합니다."
-	)
-	@ApiResponseExplanations(
-		success = @ApiSuccessResponseExplanation(
-			description = "Presigned URL 발급 성공"
-		),
-		errors = {
-			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_FOUND_STORE),
-			@ApiErrorResponseExplanation(errorCode = ErrorCode.NOT_EQUAL_STORE_OWNER)
-		}
-	)
-	ResponseEntity<ResponseBody<String>> getPresignedUrl(
-		@Parameter(hidden = true) UserPassport userPassport,
-		@RequestBody @Valid StorePresignedUrlRequest storePresignedUrlRequest);
 
 }

--- a/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
+++ b/application/yabam/yabam-core/src/main/java/com/application/presentation/store/controller/StoreController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.application.presentation.store.api.StoreApi;
-import com.application.presentation.store.dto.request.StorePresignedUrlRequest;
 import com.application.presentation.store.dto.request.StoreWriteRequest;
 import com.application.presentation.store.dto.response.MyStoreResopnse;
 import com.application.presentation.store.dto.response.StoreCursorResponse;
@@ -127,17 +126,5 @@ public class StoreController implements StoreApi {
 			MyStoreResopnse
 				.from(storeService.getMyStores(userPassport))
 		));
-	}
-
-	@PostMapping("/api/v1/store/presigned-url")
-	@HasRole(userRole = ROLE_OWNER)
-	@AssignUserPassport
-	public ResponseEntity<ResponseBody<String>> getPresignedUrl(
-		UserPassport userPassport,
-		@RequestBody @Valid StorePresignedUrlRequest storePresignedUrlRequest) {
-		return ResponseEntity
-			.ok(createSuccessResponse(
-				storeService.getPresignedUrl(userPassport, storePresignedUrlRequest.storeId(),
-					storePresignedUrlRequest.storeImageProperty())));
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/image/entity/ImageProperty.java
+++ b/domain/domain-pos/src/main/java/domain/pos/image/entity/ImageProperty.java
@@ -1,0 +1,7 @@
+package domain.pos.image.entity;
+
+public enum ImageProperty {
+	STORE_HEAD,
+	STORE_DETAIL,
+	MENU_IMAGE
+}

--- a/domain/domain-pos/src/main/java/domain/pos/image/service/ImageService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/image/service/ImageService.java
@@ -1,0 +1,33 @@
+package domain.pos.image.service;
+
+import org.springframework.stereotype.Service;
+
+import com.url.UrlHandleUtil;
+import com.vo.UserPassport;
+
+import domain.pos.image.entity.ImageProperty;
+import domain.pos.store.implement.StoreImageHandler;
+import domain.pos.store.implement.StoreValidator;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+	private final StoreValidator storeValidator;
+	private final StoreImageHandler storeImageHandler;
+
+	public String getPresignedUrl(final UserPassport ownerPassport, final Long storeId,
+		final ImageProperty imageProperty) {
+		storeValidator.validateStoreOwner(ownerPassport, storeId);
+
+		String url = UrlHandleUtil.generatreDetailUrl(storeId);
+		if (imageProperty.equals(ImageProperty.STORE_HEAD)) {
+			url = UrlHandleUtil.generatreHeadUrl(storeId);
+		}
+		if (imageProperty.equals(ImageProperty.MENU_IMAGE)) {
+			url = UrlHandleUtil.generateStoreMenuUrl(storeId);
+		}
+		return storeImageHandler.generatePresignedUrl(url);
+	}
+
+}

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/vo/StoreImageProperty.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/vo/StoreImageProperty.java
@@ -1,6 +1,0 @@
-package domain.pos.store.entity.vo;
-
-public enum StoreImageProperty {
-	STORE_HEAD,
-	STORE_DETAIL
-}

--- a/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/service/StoreService.java
@@ -7,14 +7,11 @@ import org.springframework.stereotype.Service;
 
 import com.exception.ErrorCode;
 import com.exception.ServiceException;
-import com.url.UrlHandleUtil;
 import com.vo.UserPassport;
 
 import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
 import domain.pos.store.entity.dto.StoreHeadDto;
-import domain.pos.store.entity.vo.StoreImageProperty;
-import domain.pos.store.implement.StoreImageHandler;
 import domain.pos.store.implement.StoreReader;
 import domain.pos.store.implement.StoreValidator;
 import domain.pos.store.implement.StoreWriter;
@@ -28,7 +25,6 @@ public class StoreService {
 	private final StoreWriter storeWriter;
 	private final StoreReader storeReader;
 	private final StoreValidator storeValidator;
-	private final StoreImageHandler storeImageHandler;
 
 	public Long createStore(final UserPassport ownerPassport, final StoreInfo createRequestStoreInfo) {
 		final Long savedStoreId = storeWriter.createStore(ownerPassport, createRequestStoreInfo);
@@ -67,16 +63,6 @@ public class StoreService {
 		final Store previousStore = storeValidator.validateStoreOwner(ownerPassport, storeId);
 		storeWriter.deleteStore(previousStore);
 		log.info("가게 삭제 성공 : userId={}, storeId={}", ownerPassport.getUserId(), storeId);
-	}
-
-	public String getPresignedUrl(final UserPassport ownerPassport, final Long storeId,
-		final StoreImageProperty storeImageProperty) {
-		storeValidator.validateStoreOwner(ownerPassport, storeId);
-		String url = UrlHandleUtil.generatreDetailUrl(storeId);
-		if (storeImageProperty.equals(StoreImageProperty.STORE_HEAD)) {
-			url = UrlHandleUtil.generatreHeadUrl(storeId);
-		}
-		return storeImageHandler.generatePresignedUrl(url);
 	}
 
 	public void postDetailImage(final UserPassport ownerPassport, final Long storeId, final String imageUrl) {

--- a/utils/util-url/src/main/java/com/url/UrlHandleUtil.java
+++ b/utils/util-url/src/main/java/com/url/UrlHandleUtil.java
@@ -7,6 +7,7 @@ public class UrlHandleUtil {
 	private static final String STORE_DETAIL_IMAGE_PATH_FORMAT = "/%s/%s/%s";
 	private static final String STORE_HEAD_DOMAIN_NAME = "store_head_image";
 	private static final String STORE_DETAIL_DOMAIN_NAME = "store_detail_image";
+	private static final String STORE_MENU_DOMAIN_NAME = "store_menu_image";
 
 	private UrlHandleUtil() {
 
@@ -37,6 +38,14 @@ public class UrlHandleUtil {
 	public static String generatreDetailUrl(Long storeId) {
 		return String.format(STORE_DETAIL_IMAGE_PATH_FORMAT,
 			STORE_DETAIL_DOMAIN_NAME,
+			storeId,
+			creaeteUUID()
+		);
+	}
+
+	public static String generateStoreMenuUrl(Long storeId) {
+		return String.format(STORE_HEAD_IMAGE_PATH_FORMAT,
+			STORE_MENU_DOMAIN_NAME,
 			storeId,
 			creaeteUUID()
 		);


### PR DESCRIPTION

## 🍀 작업 사항 


### 1️⃣ presigned Url 리팩터링

서비스에서 사용하는 이미지 가게 대표 이미지 , 가게 상세 이미지 , 메뉴 이미지

위 3개의 presigend url 발급에 해당하는 api 공통화하도록 리팩터링함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이미지 작업을 위한 presigned URL 발급 API 및 엔드포인트가 새로 추가되었습니다. STORE_HEAD, STORE_DETAIL, MENU_IMAGE 유형의 이미지를 지원합니다.
    - 이미지 관련 서비스가 분리되어 소유자 검증 및 URL 생성 로직이 개선되었습니다.

- **변경 사항**
    - presigned URL 발급 기능이 기존 스토어 API에서 이미지 전용 API로 이전되었습니다.
    - 이미지 유형(enum)과 요청 구조가 통합 및 확장되었습니다.

- **삭제**
    - 기존 스토어 API 및 컨트롤러에서 presigned URL 발급 관련 메서드가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->