### PR TITLE
Kafka 에서 Redis pub/sub으로 migration 

### DIFF
--- a/application/yabam/yabam-event/build.gradle
+++ b/application/yabam/yabam-event/build.gradle
@@ -19,8 +19,9 @@ dependencies {
     // domain-event
     implementation project(':domain:domain-event:store-event')
 
-    // kafka
-    runtimeOnly project(':infra:mq:kafka-pos')
+    // redis
+//    runtimeOnly project(':infra:mq:kafka-pos')
+    runtimeOnly project(':infra:mq:redis-pos')
 
     // common mvc(auth) module
     implementation project(':common:mvc')

--- a/application/yabam/yabam-event/src/main/java/com/event/EventApplication.java
+++ b/application/yabam/yabam-event/src/main/java/com/event/EventApplication.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
-	"com.pos.consumer.store.order",
+	"com.pos.global.config.consumer",
 	"com.pos.consumer",
 	"com.event"
 })

--- a/application/yabam/yabam-event/src/main/java/com/event/channel/OwnerStoreChannel.java
+++ b/application/yabam/yabam-event/src/main/java/com/event/channel/OwnerStoreChannel.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.event.implement.EmitterGenerator;
+import com.pos.channel.MqChannelHandler;
 import com.pos.event.SseChannelProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -21,12 +25,30 @@ import lombok.extern.slf4j.Slf4j;
 public class OwnerStoreChannel implements SseChannel {
 	private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
 	private static final long RECONNECTION_TIMEOUT = 1000L;
+	private static final long HEARTBEAT_INTERVAL = 10000L;  // 10 s
 	private static final SseChannelProvider CHANNEL = SseChannelProvider.OWNER_STORE;
 	private final EmitterGenerator emitterGenerator;
+	private final MqChannelHandler mqChannelHandler;
+	private final ScheduledExecutorService heartbeatPool =
+		Executors.newSingleThreadScheduledExecutor(r -> {
+			Thread thread = new Thread(r, "sse-heartbeat");
+			thread.setDaemon(true);
+			return thread;
+		});
 
 	public SseEmitter subscribe(Long storeId) {
 		SseEmitter emitter = emitterGenerator.setUpSseEmitter(CHANNEL.getChannelName(), emitterMap, storeId);
 		emitterMap.put(storeId, emitter);
+		mqChannelHandler.subscribe(storeId);
+		sendSseAck(storeId, emitter);
+
+		heartbeatPool.scheduleAtFixedRate(() ->
+				sendHeartbeat(storeId), HEARTBEAT_INTERVAL,
+			HEARTBEAT_INTERVAL, TimeUnit.MILLISECONDS);
+		return emitter;
+	}
+
+	private static void sendSseAck(Long storeId, SseEmitter emitter) {
 		try {
 			SseEmitter.SseEventBuilder event = SseEmitter.event()
 				.name(CHANNEL.getChannelName())
@@ -38,7 +60,26 @@ public class OwnerStoreChannel implements SseChannel {
 			log.warn("[{}] failure send media position data, id={}, {}", CHANNEL.getChannelName(), storeId,
 				e.getMessage());
 		}
-		return emitter;
+	}
+
+	private void sendHeartbeat(Long storeId) {
+		SseEmitter emitter = emitterMap.get(storeId);
+		if (emitter == null) {
+			return; // 이미 끊김
+		}
+		try {
+			emitter.send(SseEmitter.event().name("heartbeat").comment(""));
+		} catch (IOException ex) {
+			log.info("[{}] heartbeat failed -> closing emitter, id={}",
+				CHANNEL.getChannelName(), storeId);
+			closeEmitter(storeId, emitter);
+		}
+	}
+
+	private void closeEmitter(Long storeId, SseEmitter emitter) {
+		emitter.complete();
+		emitterMap.remove(storeId);
+		mqChannelHandler.unsubscribe(storeId);
 	}
 
 	public void unicast(String eventName, Long storeId, Object eventData) {

--- a/application/yabam/yabam-event/src/main/java/com/event/config/SseChannelConfig.java
+++ b/application/yabam/yabam-event/src/main/java/com/event/config/SseChannelConfig.java
@@ -10,6 +10,7 @@ import com.event.channel.SseChannel;
 import com.event.implement.EmitterGenerator;
 import com.event.implement.OwnerStoreValidator;
 import com.event.service.SsePosService;
+import com.pos.channel.MqChannelHandler;
 import com.pos.event.SseChannelProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,11 @@ import lombok.RequiredArgsConstructor;
 public class SseChannelConfig {
 	private final EmitterGenerator emitterGenerator;
 	private final OwnerStoreValidator ownerStoreValidator;
+	private final MqChannelHandler mqChannelHandler;
 
 	@Bean
 	public SseChannel ownerStoreChannel() {
-		return new OwnerStoreChannel(emitterGenerator);
+		return new OwnerStoreChannel(emitterGenerator, mqChannelHandler);
 	}
 
 	@Bean

--- a/application/yabam/yabam-event/src/main/java/com/event/implement/EmitterGenerator.java
+++ b/application/yabam/yabam-event/src/main/java/com/event/implement/EmitterGenerator.java
@@ -5,12 +5,17 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.pos.channel.MqChannelHandler;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class EmitterGenerator {
 	private static final long TIMEOUT = 60 * 1000 * 3;
+	private final MqChannelHandler mqChannelHandler;
 
 	public SseEmitter setUpSseEmitter(String channelName, Map<Long, SseEmitter> emitterMap, Long storeId) {
 		SseEmitter emitter = createEmitter();
@@ -28,6 +33,7 @@ public class EmitterGenerator {
 				log.info("[{}] server sent event removed in emitter cache: key={}", channelName, storeId);
 			}
 			log.info("[{}] disconnected by completed server sent event: key={}", channelName, storeId);
+			mqChannelHandler.unsubscribe(storeId);
 		});
 		return emitter;
 	}

--- a/domain/domain-event/store-event/src/main/java/com/pos/channel/MqChannelHandler.java
+++ b/domain/domain-event/store-event/src/main/java/com/pos/channel/MqChannelHandler.java
@@ -1,0 +1,7 @@
+package com.pos.channel;
+
+public interface MqChannelHandler {
+	void subscribe(Long id);
+
+	void unsubscribe(Long id);
+}

--- a/infra/mq/redis-pos/README.md
+++ b/infra/mq/redis-pos/README.md
@@ -1,0 +1,172 @@
+# Redis Pub/Sub 모듈 활용 가이드
+
+## 1. build.gradle 의존성 추가
+
+`application:yabam:yabam-core` 모듈의 build.gradle 파일에 다음과 같이 의존성을 추가합니다:
+
+```textmate
+dependencies {
+    // 기존 의존성들...
+    
+    // infra:mq:redis-pos 모듈 의존성 추가
+    implementation project(':infra:mq:redis-pos')
+}
+```
+
+## 2. 모듈 빈 설명 및 컨텍스트 로딩 설정
+
+해당 모듈에서는 Store-Order Event 관련 Produce 와 Consume을 수행하는 Redis Pub/Sub 기반 기능을 수행하는 컴포넌트들이 존재합니다
+
+크게 `Producer` 와 `Consumer` 관련 컴포넌트들이 존재합니다
+
+해당 모듈을 의존하는 dependencing 모듈에서는 Config 클래스를 이용해 Producer 혹은 Consumer 관련 빈을 로드해서 사용할 수 있습니다
+
+`driving` 모듈의 메인 애플리케이션 클래스나 설정 클래스에서 `infra:mq:redis-pos` 모듈의 컴포넌트를 스캔하도록 설정하는 예제입니다:
+
+```java
+package com.yabam.core;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@Import(RedisProducerConfig.class) // Redis 관련 설정과 Producer관련 빈으로 로딩 합니다.
+@Import(RedisConsumerConfig.class) // Redis 관련 설정과 Consumer관련 빈으로 로딩 합니다.
+public class YabamCoreApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(YabamCoreApplication.class, args);
+	}
+}
+```
+
+## 3. Kafka 설정 추가
+
+`application:yabam:yabam-core` 모듈의 application.yml(또는 properties) 파일에 KafkaStoreOrderProperties 설정을 추가합니다:
+
+프로퍼티 설정은 Redis 설정에 맞게 해주세요
+
+```yaml
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6311
+```
+
+## 주의사항
+
+1. **순환 의존성 방지**: 두 모듈 간에 순환 의존성이 생기지 않도록 주의하세요.
+2. **권한 분리**: 모듈 간 필요한 기능만 노출하고 사용하도록 인터페이스를 설계하세요.
+3. **설정 충돌**: 두 모듈에서 동일한 빈이나 설정이 충돌하지 않도록 확인하세요.
+4. **버전 관리**: 모듈 간 의존성 버전이 일치하는지 확인하세요.
+
+이 가이드를 따라 `infra:mq:redis-pos` 모듈을 `application:yabam:yabam-core` 모듈에서 사용할 수 있도록 설정하면, 코어 모듈에서 Kafka를 통한 이벤트 발행 기능을 활용할
+수 있습니다.
+
+# Redis Pub/Sub 구현사항
+
+## 1. Producer
+
+- 해당 컴포넌트는 메시지 통신 신뢰성 수준을 At-Least-Once 정도의 수준을 보장하므로 신뢰성보다는 고성능에 초점을 맞춤
+- 기존 블록킹 I/O 작업을 수행하는 RedisTemplate 말고, ReactiveRedisTemplate을 채택하여 비동기 논블록킹 I/O 작업을 수행
+-
+
+```java
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisOrderProducer implements StoreOrderProducer {
+	// 생략
+	@Override
+	public void produceStoreOrder(Store store, Table table, Order order) {
+		// 생략
+		reactiveRedisTemplate.convertAndSend(topic, storeOrderEvent)
+			.subscribeOn(Schedulers.boundedElastic())
+			.subscribe(result -> {
+				if (result > 0) {
+					log.info("Message sent to channel: {}, Subscribers: {}", topic, result);
+				} else {
+					log.info("No subscribers found for channel: {}", topic);
+				}
+			}, error -> {
+				log.warn("Failed to send message to channel: {}, Error: {}", topic, error.getMessage());
+			});
+	}
+}
+```
+
+- 비동기 처리가 가능하지만 result 를 받아서 핸들링이 가능하다.
+- 현재는 단순한 로그만 찍히는 정도이며 result 가 정수형인데 이 데이터는 현재 Redis Pub/Sub에 해당 Topic을 Subscribe 하는 Consumer 의 갯수를 의미한다.
+
+## 2. Consumer
+
+- Spring Data Redis 에서 제공하는 MessageListener 를 Implement 하여 Redis Pub/Sub 메시지를 수신하고 처리하는 로직을 수행할 수 있음
+- 수신하기 전에 해당 Topic 을 Subscribe 하는 동작이 선행되어야 하는데 이는 동적으로 Topic이 정해져야 하므로 Subscribe 동작과 Unsubscribe 하는 동작을 별도로 구현함
+- SSE 세션이 추가됨에 따라 Topic subscriber 가 늘어나게 되고 해당 Topic에 해당하는 MessageListener를 RedisMessageListenerContainer에 등록하여 메시지를
+  수신할 수 있도록 구현
+
+```java
+
+@Component
+public class RedisConsumerHandler {
+	private final RedisMessageListenerContainer container;
+	private final Map<String, MessageListener> listenerMap = new ConcurrentHashMap<>(); // 동적 Topic 관리
+	private final RedisStoreOrderListener redisStoreOrderListener;
+
+	public void subscribe(String channel) {
+		if (listenerMap.containsKey(channel)) {
+			return;
+		}
+		listenerMap.put(channel, redisStoreOrderListener);
+		container.addMessageListener(redisStoreOrderListener,
+			ChannelTopic.of(channel)); // RedisMessageListenerContainer에 MessageListener 등록
+	}
+
+	public void unsubscribe(String channel) {
+		if (!listenerMap.containsKey(channel)) {
+			return;
+		}
+		container.removeMessageListener(listenerMap.get(channel), ChannelTopic.of(channel));
+		listenerMap.remove(channel);
+	}
+}
+```
+
+## 3. Serialization
+
+```java
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisSerializerConfig {
+	@Bean
+	public GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer(ObjectMapper objectMapper) {
+		return new GenericJackson2JsonRedisSerializer(objectMapper);
+	}
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper()
+			.registerModule(new ParameterNamesModule())
+			.registerModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+}
+```
+
+| 모듈/플래그                               | 역할                                                                                     |
+|--------------------------------------|----------------------------------------------------------------------------------------|
+| **`ParameterNamesModule`**           | 자바 **record**나 `@ConstructorBinding` 객체를 역직렬화할 때, 생성자 매개변수 이름을 자동 인식합니다.               |
+| **`JavaTimeModule`**                 | `LocalDateTime`, `LocalDate`, `Instant` 등 **java.time** 타입을 ISO-8601 문자열로 직렬화/역직렬화합니다. |
+| **`WRITE_DATES_AS_TIMESTAMPS` 비활성화** | 날짜·시간을 `1624025100000` 같은 UNIX 타임스탬프가 아니라 **`"2025-06-18T15:40:12.345"`** 형식으로 유지합니다.  |
+
+
+
+
+
+
+
+
+

--- a/infra/mq/redis-pos/build.gradle
+++ b/infra/mq/redis-pos/build.gradle
@@ -1,0 +1,28 @@
+bootJar {
+    enabled = false
+}
+jar {
+    enabled = true
+}
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+    // domain-event
+    implementation project(':domain:domain-event:store-event')
+    implementation project(':domain:domain-pos')
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation project(':domain:domain-event:store-event')
+    testImplementation project(':domain:domain-pos')
+    testImplementation testFixtures(project(':domain:domain-pos'))
+
+    /* test-containers */
+    testImplementation "org.testcontainers:testcontainers:1.19.0"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
+
+
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisConsumerHandler.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisConsumerHandler.java
@@ -8,18 +8,22 @@ import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Component;
 
+import com.pos.channel.MqChannelHandler;
+import com.pos.util.ChannelPrefixUtil;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class RedisConsumerHandler {
+public class RedisConsumerHandler implements MqChannelHandler {
 	private final RedisMessageListenerContainer container;
 	private final Map<String, MessageListener> listenerMap = new ConcurrentHashMap<>();
 	private final RedisStoreOrderListener redisStoreOrderListener;
 
-	public void subscribe(String channel) {
+	public void subscribe(Long id) {
+		String channel = ChannelPrefixUtil.STORE_ORDER_PREFIX + id;
 		if (listenerMap.containsKey(channel)) {
 			log.info("이미 구독중인 channel {}", channel);
 			return;
@@ -28,7 +32,8 @@ public class RedisConsumerHandler {
 		container.addMessageListener(redisStoreOrderListener, ChannelTopic.of(channel));
 	}
 
-	public void unsubscribe(String channel) {
+	public void unsubscribe(Long id) {
+		String channel = ChannelPrefixUtil.STORE_ORDER_PREFIX + id;
 		if (!listenerMap.containsKey(channel)) {
 			log.info("구독중이지 않은 channel {}", channel);
 			return;

--- a/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisConsumerHandler.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisConsumerHandler.java
@@ -1,0 +1,39 @@
+package com.pos.consumer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisConsumerHandler {
+	private final RedisMessageListenerContainer container;
+	private final Map<String, MessageListener> listenerMap = new ConcurrentHashMap<>();
+	private final RedisStoreOrderListener redisStoreOrderListener;
+
+	public void subscribe(String channel) {
+		if (listenerMap.containsKey(channel)) {
+			log.info("이미 구독중인 channel {}", channel);
+			return;
+		}
+		listenerMap.put(channel, redisStoreOrderListener);
+		container.addMessageListener(redisStoreOrderListener, ChannelTopic.of(channel));
+	}
+
+	public void unsubscribe(String channel) {
+		if (!listenerMap.containsKey(channel)) {
+			log.info("구독중이지 않은 channel {}", channel);
+			return;
+		}
+		container.removeMessageListener(listenerMap.get(channel), ChannelTopic.of(channel));
+		listenerMap.remove(channel);
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisStoreOrderListener.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisStoreOrderListener.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.pos.event.SseChannelProvider;
 import com.pos.event.StoreOrderEvent;
+import com.pos.util.ChannelPrefixUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,8 @@ public class RedisStoreOrderListener implements MessageListener {
 
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
-		String key = new String(message.getChannel());
+		String channelName = new String(message.getChannel());
+		String key = ChannelPrefixUtil.removeStoreOrderPrefix(channelName);
 		StoreOrderEvent storeOrderEvent;
 		storeOrderEvent = serializer.deserialize(message.getBody(), StoreOrderEvent.class);
 		sseEventHandler.handleEventWithSSE(SseChannelProvider.OWNER_STORE, EVENT_NAME, key, storeOrderEvent);

--- a/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisStoreOrderListener.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/consumer/RedisStoreOrderListener.java
@@ -1,0 +1,29 @@
+package com.pos.consumer;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import com.pos.event.SseChannelProvider;
+import com.pos.event.StoreOrderEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisStoreOrderListener implements MessageListener {
+	private final SseEventHandler sseEventHandler;
+	private final GenericJackson2JsonRedisSerializer serializer;
+	private static final String EVENT_NAME = "StoreOrderEvent";
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String key = new String(message.getChannel());
+		StoreOrderEvent storeOrderEvent;
+		storeOrderEvent = serializer.deserialize(message.getBody(), StoreOrderEvent.class);
+		sseEventHandler.handleEventWithSSE(SseChannelProvider.OWNER_STORE, EVENT_NAME, key, storeOrderEvent);
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisConsumerConfig.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisConsumerConfig.java
@@ -1,0 +1,25 @@
+package com.pos.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import com.pos.consumer.RedisConsumerHandler;
+import com.pos.consumer.RedisStoreOrderListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@Import({RedisStoreOrderListener.class, RedisConsumerHandler.class, RedisSerializerConfig.class})
+@RequiredArgsConstructor
+public class RedisConsumerConfig {
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		return container;
+	}
+
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisProducerConfig.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisProducerConfig.java
@@ -1,0 +1,37 @@
+package com.pos.global.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import com.pos.producer.RedisOrderProducer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@Import({RedisAutoConfiguration.class,
+	RedisOrderProducer.class, RedisSerializerConfig.class})
+@RequiredArgsConstructor
+public class RedisProducerConfig {
+
+	@Bean
+	public ReactiveRedisTemplate<String, Object> reactiveRedisTemplate(
+		ReactiveRedisConnectionFactory reactiveRedisConnectionFactory,
+		GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer) {
+		RedisSerializationContext<String, Object> context =
+			RedisSerializationContext
+				.<String, Object>newSerializationContext(RedisSerializer.json())
+				.value(genericJackson2JsonRedisSerializer)
+				.hashValue(genericJackson2JsonRedisSerializer)
+				.build();
+		ReactiveRedisTemplate<String, Object> template = new ReactiveRedisTemplate<>(reactiveRedisConnectionFactory,
+			context);
+		return template;
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisSerializerConfig.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/global/config/RedisSerializerConfig.java
@@ -1,0 +1,29 @@
+package com.pos.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisSerializerConfig {
+	@Bean
+	public GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer(ObjectMapper objectMapper) {
+		return new GenericJackson2JsonRedisSerializer(objectMapper);
+	}
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper()
+			.registerModule(new ParameterNamesModule())
+			.registerModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/global/config/consumer/RedisConsumerConfig.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/global/config/consumer/RedisConsumerConfig.java
@@ -1,4 +1,4 @@
-package com.pos.global.config;
+package com.pos.global.config.consumer;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +8,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
 import com.pos.consumer.RedisConsumerHandler;
 import com.pos.consumer.RedisStoreOrderListener;
+import com.pos.global.config.RedisSerializerConfig;
 
 import lombok.RequiredArgsConstructor;
 

--- a/infra/mq/redis-pos/src/main/java/com/pos/global/config/producer/RedisProducerConfig.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/global/config/producer/RedisProducerConfig.java
@@ -1,4 +1,4 @@
-package com.pos.global.config;
+package com.pos.global.config.producer;
 
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +10,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
+import com.pos.global.config.RedisSerializerConfig;
 import com.pos.producer.RedisOrderProducer;
 
 import lombok.RequiredArgsConstructor;

--- a/infra/mq/redis-pos/src/main/java/com/pos/producer/RedisOrderProducer.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/producer/RedisOrderProducer.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import com.pos.event.StoreOrderEvent;
 import com.pos.producer.mapper.StoreOrderEventMapper;
+import com.pos.util.ChannelPrefixUtil;
 
 import domain.pos.order.entity.Order;
 import domain.pos.order.implement.StoreOrderProducer;
@@ -18,12 +19,11 @@ import reactor.core.scheduler.Schedulers;
 @Slf4j
 @RequiredArgsConstructor
 public class RedisOrderProducer implements StoreOrderProducer {
-	private static final String STORE_ORDER_EVENT_PREFIX = "storeId:";
 	private final ReactiveRedisTemplate<String, Object> reactiveRedisTemplate;
 
 	@Override
 	public void produceStoreOrder(Store store, Table table, Order order) {
-		String topic = STORE_ORDER_EVENT_PREFIX + store.getStoreId();
+		String topic = ChannelPrefixUtil.STORE_ORDER_PREFIX + store.getStoreId();
 		StoreOrderEvent storeOrderEvent = StoreOrderEventMapper.toStoreOrderEvent(table, order);
 		reactiveRedisTemplate.convertAndSend(topic, storeOrderEvent)
 			.subscribeOn(Schedulers.boundedElastic())

--- a/infra/mq/redis-pos/src/main/java/com/pos/producer/RedisOrderProducer.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/producer/RedisOrderProducer.java
@@ -1,0 +1,40 @@
+package com.pos.producer;
+
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.pos.event.StoreOrderEvent;
+import com.pos.producer.mapper.StoreOrderEventMapper;
+
+import domain.pos.order.entity.Order;
+import domain.pos.order.implement.StoreOrderProducer;
+import domain.pos.store.entity.Store;
+import domain.pos.table.entity.Table;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.scheduler.Schedulers;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisOrderProducer implements StoreOrderProducer {
+	private static final String STORE_ORDER_EVENT_PREFIX = "storeId:";
+	private final ReactiveRedisTemplate<String, Object> reactiveRedisTemplate;
+
+	@Override
+	public void produceStoreOrder(Store store, Table table, Order order) {
+		String topic = STORE_ORDER_EVENT_PREFIX + store.getStoreId();
+		StoreOrderEvent storeOrderEvent = StoreOrderEventMapper.toStoreOrderEvent(table, order);
+		reactiveRedisTemplate.convertAndSend(topic, storeOrderEvent)
+			.subscribeOn(Schedulers.boundedElastic())
+			.subscribe(result -> {
+				if (result > 0) {
+					log.info("Message sent to channel: {}, Subscribers: {}", topic, result);
+				} else {
+					log.info("No subscribers found for channel: {}", topic);
+				}
+			}, error -> {
+				log.warn("Failed to send message to channel: {}, Error: {}", topic, error.getMessage());
+			});
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/producer/mapper/StoreOrderEventMapper.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/producer/mapper/StoreOrderEventMapper.java
@@ -1,0 +1,38 @@
+package com.pos.producer.mapper;
+
+import java.util.List;
+
+import com.pos.event.StoreOrderEvent;
+
+import domain.pos.order.entity.Order;
+import domain.pos.table.entity.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StoreOrderEventMapper {
+	public static StoreOrderEvent toStoreOrderEvent(Table table, Order order) {
+		List<StoreOrderEvent.OrderDto.OrderMenuDto> orderMenus = order.getOrderMenus().stream()
+			.map(orderMenu -> {
+				return StoreOrderEvent.OrderDto.OrderMenuDto.builder()
+					.menuId(orderMenu.getOrderMenuId())
+					.menuName(orderMenu.getMenu().getMenuInfo().getName())
+					.menuPrice(orderMenu.getMenu().getMenuInfo().getPrice())
+					.menuCount(orderMenu.getQuantity())
+					.build();
+			})
+			.toList();
+		return StoreOrderEvent.builder()
+			.tableId(table.getTableId())
+			.tableNumber(table.getTableNumber())
+			.orderDto(
+				StoreOrderEvent.OrderDto.builder()
+					.orderId(order.getOrderId())
+					.orderMenuDtos(orderMenus)
+					.orderStatus(order.getOrderStatus().name())
+					// TODO : order.getCreatedAt() 추가되면 여기에 추가해야함
+					.build()
+			)
+			.build();
+	}
+}

--- a/infra/mq/redis-pos/src/main/java/com/pos/util/ChannelPrefixUtil.java
+++ b/infra/mq/redis-pos/src/main/java/com/pos/util/ChannelPrefixUtil.java
@@ -1,0 +1,12 @@
+package com.pos.util;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class ChannelPrefixUtil {
+	public static final String STORE_ORDER_PREFIX = "storeId:";
+
+	public static String removeStoreOrderPrefix(String channelName) {
+		return channelName.replace(STORE_ORDER_PREFIX, "");
+	}
+}

--- a/infra/mq/redis-pos/src/test/java/com/pos/producer/RedisOrderProducerTest.java
+++ b/infra/mq/redis-pos/src/test/java/com/pos/producer/RedisOrderProducerTest.java
@@ -10,8 +10,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.pos.consumer.RedisConsumerHandler;
 import com.pos.consumer.SseEventHandler;
-import com.pos.global.config.RedisConsumerConfig;
-import com.pos.global.config.RedisProducerConfig;
+import com.pos.global.config.consumer.RedisConsumerConfig;
+import com.pos.global.config.producer.RedisProducerConfig;
 import com.pos.producer.config.RedisConfig;
 
 import domain.pos.order.entity.Order;
@@ -40,7 +40,7 @@ class RedisOrderProducerTest {
 		Order order = OrderFixture.GENERAL_ORDER();
 		Store store = order.getReceipt().getSale().getStore();
 		Table table = order.getReceipt().getTable();
-		redisConsumerHandler.subscribe(CHANNEL_PREFIX + store.getStoreId());
+		redisConsumerHandler.subscribe(store.getStoreId());
 
 		// when
 		redisOrderProducer.produceStoreOrder(store, table, order);

--- a/infra/mq/redis-pos/src/test/java/com/pos/producer/RedisOrderProducerTest.java
+++ b/infra/mq/redis-pos/src/test/java/com/pos/producer/RedisOrderProducerTest.java
@@ -1,0 +1,51 @@
+package com.pos.producer;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.pos.consumer.RedisConsumerHandler;
+import com.pos.consumer.SseEventHandler;
+import com.pos.global.config.RedisConsumerConfig;
+import com.pos.global.config.RedisProducerConfig;
+import com.pos.producer.config.RedisConfig;
+
+import domain.pos.order.entity.Order;
+import domain.pos.store.entity.Store;
+import domain.pos.table.entity.Table;
+import fixtures.order.OrderFixture;
+
+@SpringBootTest(classes = {RedisProducerConfig.class, RedisConsumerConfig.class, RedisConfig.class})
+@ActiveProfiles("test")
+class RedisOrderProducerTest {
+
+	@Autowired
+	private RedisOrderProducer redisOrderProducer;
+
+	@Autowired
+	private RedisConsumerHandler redisConsumerHandler;
+
+	@MockitoBean
+	private SseEventHandler sseEventHandler;
+
+	private static final String CHANNEL_PREFIX = "storeId:";
+
+	@Test
+	void produce_consume_통합테스트() throws InterruptedException {
+		// given
+		Order order = OrderFixture.GENERAL_ORDER();
+		Store store = order.getReceipt().getSale().getStore();
+		Table table = order.getReceipt().getTable();
+		redisConsumerHandler.subscribe(CHANNEL_PREFIX + store.getStoreId());
+
+		// when
+		redisOrderProducer.produceStoreOrder(store, table, order);
+		// then
+		verify(sseEventHandler, timeout(1000))
+			.handleEventWithSSE(any(), any(), any(), any());
+	}
+}

--- a/infra/mq/redis-pos/src/test/java/com/pos/producer/config/RedisConfig.java
+++ b/infra/mq/redis-pos/src/test/java/com/pos/producer/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.pos.producer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.testcontainers.containers.GenericContainer;
+
+@Configuration
+public class RedisConfig {
+
+	private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+	private static final int REDIS_PORT = 6379;  // 기본 포트로 변경
+	private static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
+		.withExposedPorts(REDIS_PORT)
+		.withReuse(true);
+
+	static {
+		REDIS_CONTAINER.start();
+	}
+
+	@Bean
+	public RedisStandaloneConfiguration redisConfiguration() {
+		return new RedisStandaloneConfiguration(
+			REDIS_CONTAINER.getHost(), REDIS_CONTAINER.getMappedPort(REDIS_PORT)
+		);
+	}
+}

--- a/infra/mq/redis-pos/src/test/resources/application-test.yml
+++ b/infra/mq/redis-pos/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6311

--- a/infra/rdb/pos/src/test/resources/application-test.yml
+++ b/infra/rdb/pos/src/test/resources/application-test.yml
@@ -17,3 +17,4 @@ spring:
         format_sql: true
         use_sql_comments: true
         show_sql: true
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,9 @@ include(":domain:domain-event:store-event")
 include(":infra:rdb:pos")
 include(":infra:mq:kafka-pos")
 include(":infra:aws:infra-s3")
+include(":infra:mq:redis-pos")
 
 // utils
 include(":utils:util-uuid")
 include(":utils:util-url")
+


### PR DESCRIPTION
## 🍀 작업 사항

### 1️⃣ Kafka 에서 Redis Pub/Sub 으로 전환

#### 전환 이유 1 Kafka 의 메시지 신뢰성 수준 (At-Least Once, Exactly Once) 의 필요성 낮아짐

- 저번 pr 에서 SSE 의 메시지 신뢰성 보장에 대해 구조적인 한계 때문에 fetch api 와 혼용하여 실시간 주문 데이터 응답의 신뢰성과 안정성을 높였습니다
- 따라서 At-Most Once 수준의 메시지 브로커만 필요하게 되었습니다.

#### 전환 이유 2 subscriber 구조

- 기존 카프카는 sse 서버를 scale-out 을 하면 다음과 같이 구성됩니다.

![image](https://github.com/user-attachments/assets/753724f7-5fd9-4a25-a5e7-512e7cabc662)

- 카프카의 topic 특성상 동적으로 topic 을 잘 생성하지 않기 때문에 1번 store 와 세션이 연결되지 않아도 해당 데이터를 consume 하고 해당 세션에 store 1 이 연결되어 있는지 검증하는 과정을 거쳤습니다.
- 이러한 unicating 적인 연결에 한계점을 확인했습니다.

- Redis Pub/Sub을 도입하면 다음과 같이 구성됩니다.

![image](https://github.com/user-attachments/assets/11622ceb-4e1d-4faf-9225-738f95298c30)

Redis는 카프카와 다르게 해당 관심있는 데이터를 컨슈머가 polling 하는 구조가 아닌 Redis가 연결된 subscriber 와 세션을 기억하고 해당 subscriber 에게 push하는 구조라 가능합니다.

- 추가로 동적으로 subscibe 하게 구현하였고 Kafka 와는 다르게 subscribe unsubscribe 하는 동작을 추가 구현했습니다

#### 전환 이유 3 자원 절약

- Kafka 는 기본적으로 주키퍼와 브로커 3대로 운영하는 것이 일반적입니다. 높은 처리량과 신뢰성이 강점인데 현재 규모에서 구조와도 알맞지 않은데 kafka 같은 플랫폼을 도입하는 것보다 Redis 를 도입하는 것이 자원 절약에 도움이 될거라 판단했습니다.

### 2️⃣ SSE 커넥션 안정성 향상

- 기존에 구현했던 SSE 에서 연결이 timeout 이 아닌 장애로 연결이 끊긴 경우 timeout 시간까지 대기하다가 제거되는 걸로 알고 있었는데요 (혹은 에러 발생시) 이러한 구조에서 안정성 향상을 위해 15초 주기로 heartbeat 을 날려서 클라이언트도 해당 커넥션이 신뢰성이 있는지 판단할 수 있고 장애를 빠르게 확인할 수 있도록 구현했습니다


