### PR TITLE
store 관련 infra 계층 리팩터링

### DIFF
--- a/domain/domain-pos/src/main/java/domain/pos/sale/adapter/service/SaleHandler.java
+++ b/domain/domain-pos/src/main/java/domain/pos/sale/adapter/service/SaleHandler.java
@@ -31,7 +31,7 @@ public class SaleHandler implements SaleCommand, SaleRead {
 
 		store.openStore();
 
-		storeRepository.updateIsOpen(store);
+		storeRepository.save(store);
 
 		Sale sale = Sale.createOpenSale(store.getId());
 
@@ -48,7 +48,7 @@ public class SaleHandler implements SaleCommand, SaleRead {
 
 		store.closeStore();
 
-		storeRepository.updateIsOpen(store);
+		storeRepository.save(store);
 
 		sale.close(isNotExistsNonAdjustReceipt(sale));
 

--- a/domain/domain-pos/src/main/java/domain/pos/store/adapter/service/StoreCommandImpl.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/adapter/service/StoreCommandImpl.java
@@ -26,7 +26,7 @@ public class StoreCommandImpl implements StoreCommand {
 	public Store createStore(UserPassport ownerPassport, StoreInfo createRequestStoreInfo) {
 		var store = Store.create(ownerPassport, createRequestStoreInfo);
 
-		return storeRepository.saveStore(store);
+		return storeRepository.save(store);
 	}
 
 	@Transactional
@@ -39,7 +39,7 @@ public class StoreCommandImpl implements StoreCommand {
 
 		savedStore.update(ownerPassport, modifyStoreInfo);
 
-		return storeRepository.updateStore(savedStore);
+		return storeRepository.save(savedStore);
 	}
 
 	@Transactional

--- a/domain/domain-pos/src/main/java/domain/pos/store/entity/DetailImages.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/entity/DetailImages.java
@@ -27,10 +27,10 @@ public class DetailImages {
 		return List.copyOf(imageUrls);
 	}
 
-	public static DetailImages of(Store store, List<String> imageUrl) {
+	public static DetailImages of(Long storeId, List<String> imageUrl) {
 		var detailImage = new DetailImages();
 
-		detailImage.storeId = store.getId();
+		detailImage.storeId = requireNonNull(storeId);
 		detailImage.imageUrls = requireNonNull(imageUrl);
 
 		return detailImage;
@@ -51,14 +51,14 @@ public class DetailImages {
 	public void remove(String imageUrl) {
 		validatePattern(imageUrl);
 
-		if (isDetailImageContain(imageUrl)) {
+		if (isNotContainDetailImage(imageUrl)) {
 			throw new ServiceException(NOT_FOUND_STORE_DETAIL_IMAGE);
 		}
 
 		this.imageUrls.remove(imageUrl);
 	}
 
-	private boolean isDetailImageContain(String imageUrl) {
+	private boolean isNotContainDetailImage(String imageUrl) {
 		return !this.imageUrls.contains(imageUrl);
 	}
 }

--- a/domain/domain-pos/src/main/java/domain/pos/store/port/required/StoreRepository.java
+++ b/domain/domain-pos/src/main/java/domain/pos/store/port/required/StoreRepository.java
@@ -14,37 +14,39 @@ import domain.pos.store.entity.dto.StoreHeadDto;
 
 @Repository
 public interface StoreRepository {
+	// deprecated
 	Long createStore(UserPassport userPassport, StoreInfo createRequestStoreInfo);
 
 	Optional<Store> findStoreByStoreId(Long storeId);
 
+	// deprecated
 	Store changeStoreInfo(Store previousStore, StoreInfo requestChangeStoreInfo);
 
 	void deleteStore(Store previousStore);
 
+	// deprecated
 	Store changeStoreOpenStatus(Store previousStore);
 
+	// deprecated
 	boolean isExistsById(Long storeId);
 
+	// deprecated
 	void postDetailImage(Store previousStore, String imageUrl);
 
+	// deprecated
 	boolean isExistsImageUrl(Long storeId, String imageUrl);
 
+	// deprecated
 	void deleteDetailImage(Store previousStore, String imageUrl);
 
 	Slice<StoreHeadDto> findStoresCursorOrderByCreated(Long lastStoreId, int size);
 
 	List<Store> findMyStores(Long userId);
 
+	// deprecated
 	Optional<Store> findStoreByStoreIdWithLock(Long queryStoreId);
 
-	Store saveStore(Store store);
-
-	Store updateStore(Store store);
-
-	Optional<Store> findStore(Long queryStoreId);
+	Store save(Store store);
 
 	boolean isExistsByStoreIdAndUserId(Long queryStoreId, Long userId);
-
-	void updateIsOpen(Store store);
 }

--- a/domain/domain-pos/src/test/java/domain/pos/menu/implement/v2/MenuOrderAllocatorTest.java
+++ b/domain/domain-pos/src/test/java/domain/pos/menu/implement/v2/MenuOrderAllocatorTest.java
@@ -141,7 +141,7 @@ class MenuOrderAllocatorTest {
 		Long menuId = menu.getId();
 		Long categoryId = menu.getMenuCategoryId();
 		Integer deletedOrder = menu.getOrder();
-		
+
 		given(menuRepository.refrsh(menu)).willReturn(menu);
 
 		// when

--- a/domain/domain-pos/src/testFixtures/java/fixtures/store/DetailImagesFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/store/DetailImagesFixture.java
@@ -15,10 +15,10 @@ public class DetailImagesFixture {
 		return DetailImages.of(GENERAL_CLOSE_STORE().getId(), imageUrls);
 	}
 
-	public static DetailImages DIFF_IMAGE_FIXTURE() {
+	public static DetailImages DIFF_IMAGE_FIXTURE(Long storeId) {
 		String imageUrl = "https://example.com/diff_image.jpg";
 		List<String> imageUrls = new ArrayList<>(List.of(imageUrl));
 
-		return DetailImages.of(GENERAL_CLOSE_STORE().getId(), imageUrls);
+		return DetailImages.of(storeId, imageUrls);
 	}
 }

--- a/domain/domain-pos/src/testFixtures/java/fixtures/store/DetailImagesFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/store/DetailImagesFixture.java
@@ -12,6 +12,13 @@ public class DetailImagesFixture {
 		String imageUrl = "https://example.com/image.jpg";
 		List<String> imageUrls = new ArrayList<>(List.of(imageUrl));
 
-		return DetailImages.of(STORE_FIXTURE(), imageUrls);
+		return DetailImages.of(GENERAL_CLOSE_STORE().getId(), imageUrls);
+	}
+
+	public static DetailImages DIFF_IMAGE_FIXTURE() {
+		String imageUrl = "https://example.com/diff_image.jpg";
+		List<String> imageUrls = new ArrayList<>(List.of(imageUrl));
+
+		return DetailImages.of(GENERAL_CLOSE_STORE().getId(), imageUrls);
 	}
 }

--- a/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreFixture.java
+++ b/domain/domain-pos/src/testFixtures/java/fixtures/store/StoreFixture.java
@@ -82,4 +82,11 @@ public class StoreFixture {
 
 		return Store.create(passport, storeInfo);
 	}
+
+	public static Store DIFF_STORE_FIXTURE() {
+		var passport = OWNER_USER_PASSPORT();
+		var storeInfo = CHANGED_GENERAL_STORE_INFO();
+
+		return Store.create(passport, storeInfo);
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/global/id/IdMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/global/id/IdMapper.java
@@ -1,17 +1,39 @@
 package com.pos.global.id;
 
+import static java.util.Objects.*;
+
 import java.lang.reflect.Field;
 
 public class IdMapper {
 	public static void idMapping(Object entity, Long id) {
+		requireNonNull(entity, "entity must not be null");
+		requireNonNull(id, "id must not be null");
+
 		try {
-			Field field = entity.getClass().getDeclaredField("id");
+			Field field = findField(entity.getClass(), "id");
+			if (field == null) {
+				throw new IllegalStateException("No field named 'id' found on " + entity.getClass().getName());
+			}
+
+			Class<?> type = field.getType();
+			if (!(type == Long.class || type == long.class)) {
+				throw new IllegalStateException("'id' field must be Long/long but was " + type.getName());
+			}
 
 			field.setAccessible(true);
-
 			field.set(entity, id);
-		} catch (NoSuchFieldException | IllegalAccessException e) {
-			throw new RuntimeException(e);
+		} catch (IllegalAccessException e) {
+			throw new IllegalStateException("Failed to set 'id' via reflection", e);
 		}
+	}
+
+	private static Field findField(Class<?> type, String name) {
+		for (Class<?> cls = type; cls != null; cls = cls.getSuperclass()) {
+			try {
+				return cls.getDeclaredField(name);
+			} catch (NoSuchFieldException ignore) {
+			}
+		}
+		return null;
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/global/id/IdMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/global/id/IdMapper.java
@@ -1,0 +1,17 @@
+package com.pos.global.id;
+
+import java.lang.reflect.Field;
+
+public class IdMapper {
+	public static void idMapping(Object entity, Long id) {
+		try {
+			Field field = entity.getClass().getDeclaredField("id");
+
+			field.setAccessible(true);
+
+			field.set(entity, id);
+		} catch (NoSuchFieldException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/entity/StoreEntity.java
@@ -10,6 +10,7 @@ import com.pos.global.base.entity.BaseEntity;
 import com.pos.store.vo.StorePoint;
 import com.pos.store.vo.TableCostPerTime;
 
+import domain.pos.store.entity.Store;
 import domain.pos.store.entity.StoreInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -103,6 +104,31 @@ public class StoreEntity extends BaseEntity {
 
 	public static StoreEntity from(Long storeId) {
 		return new StoreEntity(storeId);
+	}
+
+	public static StoreEntity of(Store store) {
+		if (store == null) {
+			return null;
+		}
+
+		return mappingToEntity(store);
+	}
+
+	private static StoreEntity mappingToEntity(Store store) {
+		var entity = new StoreEntity();
+
+		entity.id = store.getId();
+		entity.isOpen = store.getIsOpen();
+		entity.ownerId = store.getOwnerPassport().getUserId();
+		entity.name = store.getStoreInfo().getStoreName();
+		entity.location = StorePoint.of(store.getStoreInfo().getLocation().x, store.getStoreInfo().getLocation().y);
+		entity.university = store.getStoreInfo().getUniversity();
+		entity.description = store.getStoreInfo().getDescription();
+		entity.headImageUrl = store.getStoreInfo().getHeadImageUrl();
+		entity.tableCostPerTime = TableCostPerTime.of(store.getStoreInfo().getTableTime(),
+			store.getStoreInfo().getTableCost());
+
+		return entity;
 	}
 
 	public void changeStoreInfo(StoreInfo requestChangeStoreInfo) {

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -124,4 +124,12 @@ public class StoreMapper {
 				.toList()
 		);
 	}
+
+	public static String toDetailImage(StoreDetailImageEntity entity) {
+		return entity.getImageUrl();
+	}
+
+	public static StoreDetailImageEntity toDetailImageEntity(String url, Long storeId) {
+		return StoreDetailImageEntity.of(url, StoreEntity.from(storeId));
+	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/mapper/StoreMapper.java
@@ -31,6 +31,10 @@ public class StoreMapper {
 		);
 	}
 
+	public static StoreEntity toStoreEntity(Store store) {
+		return StoreEntity.of(store);
+	}
+
 	public static StoreEntity toStoreEntity(Long storeId) {
 		return StoreEntity.from(storeId);
 	}
@@ -64,6 +68,7 @@ public class StoreMapper {
 		if (storeEntity == null) {
 			return null;
 		}
+
 		return Store.of(
 			storeEntity.getId(),
 			storeEntity.isOpen(),

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/DetailImageJpaRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/DetailImageJpaRepository.java
@@ -1,0 +1,15 @@
+package com.pos.store.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.pos.store.entity.StoreDetailImageEntity;
+
+@Repository
+public interface DetailImageJpaRepository extends JpaRepository<StoreDetailImageEntity, Long> {
+	List<StoreDetailImageEntity> findByStoreId(Long storeId);
+
+	void deleteByImageUrl(String imageUrl);
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreJpaRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreJpaRepository.java
@@ -8,4 +8,5 @@ import com.pos.store.repository.dsl.StoreDslRepository;
 
 @Repository
 public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long>, StoreDslRepository {
+	boolean existsByIdAndOwnerId(Long storeId, Long userId);
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/StoreRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.pos.store.repository;
 
-import java.time.LocalDateTime;
+import static com.pos.global.id.IdMapper.*;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -45,14 +46,8 @@ public class StoreRepositoryImpl implements StoreRepository {
 
 	@Override
 	public Optional<Store> findStoreByStoreId(Long storeId) {
-		StoreEntity storeEntities = queryFactory
-			.select(qStoreEntity)
-			.from(qStoreEntity)
-			.leftJoin(qStoreEntity.storeDetailImageEntity, qStoreDetailImageEntity).fetchJoin()
-			.where(qStoreEntity.id.eq(storeId))
-			.fetchOne();
-
-		return StoreMapper.toStoreWithStoreDetailImages(storeEntities);
+		return storeJpaRepository.findStoreWithDetailImageByStoreId(storeId)
+			.map(StoreMapper::toStoreWithDetailImages);
 	}
 
 	@Override
@@ -67,10 +62,7 @@ public class StoreRepositoryImpl implements StoreRepository {
 	@Override
 	@Transactional
 	public void deleteStore(Store previousStore) {
-		queryFactory.update(qStoreEntity)
-			.where(qStoreEntity.id.eq(previousStore.getId()))
-			.set(qStoreEntity.deletedAt, LocalDateTime.now())
-			.execute();
+		storeJpaRepository.deleteById(previousStore.getId());
 	}
 
 	@Override
@@ -155,26 +147,20 @@ public class StoreRepositoryImpl implements StoreRepository {
 	}
 
 	@Override
-	public Store saveStore(Store store) {
-		return null;
-	}
+	public Store save(Store store) {
+		var entity = StoreEntity.of(store);
 
-	@Override
-	public Store updateStore(Store store) {
-		return null;
-	}
+		storeJpaRepository.save(entity);
 
-	@Override
-	public Optional<Store> findStore(Long queryStoreId) {
-		return Optional.empty();
+		if (store.getId() == null) {
+			idMapping(store, entity.getId());
+		}
+
+		return store;
 	}
 
 	@Override
 	public boolean isExistsByStoreIdAndUserId(Long queryStoreId, Long userId) {
-		return false;
-	}
-
-	@Override
-	public void updateIsOpen(Store store) {
+		return storeJpaRepository.existsByIdAndOwnerId(queryStoreId, userId);
 	}
 }

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepository.java
@@ -1,10 +1,16 @@
 package com.pos.store.repository.dsl;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Slice;
+
+import com.pos.store.entity.StoreEntity;
 
 import domain.pos.store.entity.dto.StoreHeadDto;
 
 public interface StoreDslRepository {
+	Optional<StoreEntity> findStoreWithDetailImageByStoreId(Long storeId);
+
 	Slice<StoreHeadDto> findStoreHeadsByStoreIdCursor(
 		Long lastStoreId,
 		int size);

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/dsl/StoreDslRepositoryImpl.java
@@ -1,13 +1,13 @@
 package com.pos.store.repository.dsl;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
-import com.pos.review.entity.QReviewEntity;
 import com.pos.store.entity.QStoreDetailImageEntity;
 import com.pos.store.entity.QStoreEntity;
 import com.pos.store.entity.StoreEntity;
@@ -25,8 +25,18 @@ public class StoreDslRepositoryImpl implements StoreDslRepository {
 	private final JPAQueryFactory queryFactory;
 
 	private final QStoreEntity store = QStoreEntity.storeEntity;
-	private final QReviewEntity review = QReviewEntity.reviewEntity;
 	private final QStoreDetailImageEntity storeDetailImage = QStoreDetailImageEntity.storeDetailImageEntity;
+
+	@Override
+	public Optional<StoreEntity> findStoreWithDetailImageByStoreId(Long storeId) {
+		StoreEntity storeEntity = queryFactory
+			.select(store)
+			.from(store)
+			.leftJoin(store.storeDetailImageEntity, storeDetailImage).fetchJoin()
+			.where(store.id.eq(storeId))
+			.fetchOne();
+		return Optional.ofNullable(storeEntity);
+	}
 
 	@Override
 	public Slice<StoreHeadDto> findStoreHeadsByStoreIdCursor(

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/port/DetailImageRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/port/DetailImageRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.pos.store.repository.port;
+
+import org.springframework.stereotype.Repository;
+
+import com.pos.store.mapper.StoreMapper;
+import com.pos.store.repository.DetailImageJpaRepository;
+
+import domain.pos.store.entity.DetailImages;
+import domain.pos.store.port.required.DetailImageRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DetailImageRepositoryImpl implements DetailImageRepository {
+	private final DetailImageJpaRepository detailImageJpaRepository;
+
+	@Override
+	public DetailImages findByStoreId(Long queryStoreId) {
+		var list = detailImageJpaRepository.findByStoreId(queryStoreId)
+			.stream()
+			.map(StoreMapper::toDetailImage)
+			.toList();
+		return DetailImages.of(queryStoreId, list);
+	}
+
+	@Override
+	public void save(DetailImages detailImages) {
+		// 기존에 있던 이미지 중에서 요청에 없는 이미지는 삭제
+		detailImageJpaRepository.findByStoreId(detailImages.getStoreId())
+			.stream()
+			.filter(entity ->
+				!detailImages.getImageUrls().contains(entity.getImageUrl()))
+			.forEach(entity -> detailImageJpaRepository.deleteByImageUrl(entity.getImageUrl()));
+
+		// 요청에 있는 이미지 중에서 기존에 없던 이미지는 추가
+		var list = detailImages.getImageUrls().stream()
+			.map(url -> StoreMapper.toDetailImageEntity(url, detailImages.getStoreId()))
+			.toList();
+
+		detailImageJpaRepository.saveAll(list);
+	}
+}

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/port/DetailImageRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/port/DetailImageRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.pos.store.repository.port;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.pos.store.mapper.StoreMapper;
 import com.pos.store.repository.DetailImageJpaRepository;
@@ -24,13 +25,14 @@ public class DetailImageRepositoryImpl implements DetailImageRepository {
 	}
 
 	@Override
+	@Transactional
 	public void save(DetailImages detailImages) {
 		// 기존에 있던 이미지 중에서 요청에 없는 이미지는 삭제
 		detailImageJpaRepository.findByStoreId(detailImages.getStoreId())
 			.stream()
 			.filter(entity ->
 				!detailImages.getImageUrls().contains(entity.getImageUrl()))
-			.forEach(entity -> detailImageJpaRepository.deleteByImageUrl(entity.getImageUrl()));
+			.forEach(detailImageJpaRepository::delete);
 
 		// 요청에 있는 이미지 중에서 기존에 없던 이미지는 추가
 		var list = detailImages.getImageUrls().stream()

--- a/infra/rdb/pos/src/main/java/com/pos/store/repository/port/StoreRepositoryImpl.java
+++ b/infra/rdb/pos/src/main/java/com/pos/store/repository/port/StoreRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.pos.store.repository;
+package com.pos.store.repository.port;
 
 import static com.pos.global.id.IdMapper.*;
 
@@ -16,6 +16,8 @@ import com.pos.store.entity.QStoreEntity;
 import com.pos.store.entity.StoreDetailImageEntity;
 import com.pos.store.entity.StoreEntity;
 import com.pos.store.mapper.StoreMapper;
+import com.pos.store.repository.StoreDetailImageJpaRepository;
+import com.pos.store.repository.StoreJpaRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.vo.UserPassport;
 

--- a/infra/rdb/pos/src/test/java/com/pos/global/id/IdMapperTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/global/id/IdMapperTest.java
@@ -1,0 +1,67 @@
+package com.pos.global.id;
+
+import static com.pos.global.id.IdMapper.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class IdMapperTest {
+
+	class Dummy {
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	class DummyFail {
+		private UUID id;
+
+		public UUID getId() {
+			return id;
+		}
+	}
+
+	@Test
+	void createTest() {
+		var dummy = new Dummy();
+		var id = 1L;
+
+		idMapping(dummy, id);
+
+		assertThat(dummy.getId()).isEqualTo(id);
+	}
+
+	@Test
+	void createFailTest() {
+		var dummy = new DummyFail();
+		var id = 1L;
+
+		assertThatThrownBy(() -> idMapping(dummy, id))
+			.isInstanceOf(IllegalStateException.class);
+		assertThatThrownBy(() -> idMapping(dummy, null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	class ChildDummy extends Dummy {
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Test
+	void createChildTest() {
+		var dummy = new ChildDummy();
+		var id = 1L;
+
+		idMapping(dummy, id);
+
+		assertThat(dummy.getId()).isEqualTo(id);
+	}
+
+}

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/StoreRepositoryImplTest.java
@@ -4,6 +4,7 @@ import static com.pos.fixtures.sale.SaleFixture.*;
 import static com.pos.fixtures.store.StoreDetailImageFixture.*;
 import static com.pos.fixtures.store.StoreEntityFixture.*;
 import static fixtures.store.StoreFixture.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Slice;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.pos.fixtures.table.TableEntityFixture;
 import com.pos.global.config.RepositoryTest;
@@ -34,6 +36,35 @@ class StoreRepositoryImplTest extends RepositoryTest {
 
 	@Autowired
 	private StoreRepository storeRepository;
+
+	@Test
+	void saveTest() {
+		var store = STORE_FIXTURE();
+
+		storeRepository.save(store);
+
+		assertThat(store.getId()).isNotNull();
+	}
+
+	@Test
+	void saveForUpdateTest() {
+		var entity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_CLOSE_STORE()));
+		Store changed = DIFF_STORE_FIXTURE();
+		ReflectionTestUtils.setField(changed, "id", entity.getId());
+
+		// when
+		storeRepository.save(changed);
+
+		testEntityManager.flush();
+		testEntityManager.clear();
+
+		// then
+		var findEntity = testEntityManager.find(StoreEntity.class, entity.getId());
+		var findStore = StoreMapper.toStore(findEntity);
+
+		assertThat(findStore.getStoreInfo()).isEqualTo(DIFF_STORE_FIXTURE().getStoreInfo());
+		assertThat(findStore.getStoreInfo()).isNotEqualTo(GENERAL_CLOSE_STORE().getStoreInfo());
+	}
 
 	@Test
 	void StoreInfo_변경_테스트() {

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
@@ -42,7 +42,7 @@ class DetailImageRepositoryImplTest extends RepositoryTest {
 		em.flush();
 		em.clear();
 
-		var changedDetailImage = DIFF_IMAGE_FIXTURE();
+		var changedDetailImage = DIFF_IMAGE_FIXTURE(storeEntity.getId());
 
 		// when
 		detailImageRepository.save(changedDetailImage);

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
@@ -1,0 +1,60 @@
+package com.pos.store.repository.port;
+
+import static com.pos.fixtures.store.StoreDetailImageFixture.*;
+import static com.pos.fixtures.store.StoreEntityFixture.*;
+import static fixtures.store.DetailImagesFixture.*;
+import static fixtures.store.StoreFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.pos.global.config.RepositoryTest;
+
+class DetailImageRepositoryImplTest extends RepositoryTest {
+
+	@Autowired
+	DetailImageRepositoryImpl detailImageRepository;
+
+	@Autowired
+	TestEntityManager em;
+
+	@Test
+	void findByStoreIdTest() {
+		var storeEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_CLOSE_STORE()));
+		var storeDetailImageEntities = testFixtureBuilder.buildStoreDetailImageEntities(
+			CUSTOM_STORE_DETAIL_IMAGES(storeEntity));
+		em.flush();
+		em.clear();
+
+		var result = detailImageRepository.findByStoreId(storeEntity.getId());
+
+		assertThat(result.getImageUrls().size()).isEqualTo(storeDetailImageEntities.size());
+		assertThat(result.getStoreId()).isEqualTo(storeEntity.getId());
+	}
+
+	@Test
+	void saveTest() {
+		var storeEntity = testFixtureBuilder.buildStoreEntity(CUSTOME_STORE_ENTITY(GENERAL_CLOSE_STORE()));
+		var storeDetailImageEntities = testFixtureBuilder.buildStoreDetailImageEntities(
+			CUSTOM_STORE_DETAIL_IMAGES(storeEntity));
+		em.flush();
+		em.clear();
+
+		var changedDetailImage = DIFF_IMAGE_FIXTURE();
+
+		// when
+		detailImageRepository.save(changedDetailImage);
+		em.flush();
+		em.clear();
+
+		var result = detailImageRepository.findByStoreId(storeEntity.getId());
+
+		assertThat(result.getImageUrls().size()).isEqualTo(changedDetailImage.getImageUrls().size());
+		assertThat(result.getImageUrls().get(0)).contains(changedDetailImage.getImageUrls());
+
+		assertThat(result.getStoreId()).isEqualTo(storeEntity.getId());
+	}
+
+}

--- a/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
+++ b/infra/rdb/pos/src/test/java/com/pos/store/repository/port/DetailImageRepositoryImplTest.java
@@ -12,10 +12,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import com.pos.global.config.RepositoryTest;
 
+import domain.pos.store.port.required.DetailImageRepository;
+
 class DetailImageRepositoryImplTest extends RepositoryTest {
 
 	@Autowired
-	DetailImageRepositoryImpl detailImageRepository;
+	DetailImageRepository detailImageRepository;
 
 	@Autowired
 	TestEntityManager em;


### PR DESCRIPTION
## 🍀 작업 사항


### 1️⃣ Store , DetailImage Infra 계층 리팩터링

- 기존 도메인 계층 구현할 때 infra 를 구현을 안하고  지나쳤는데 해당 미흡 사항 구현했습니다.
- 구현하면서 이제 안쓰일 메서드들은 주석처리 했습니다.

### 2️⃣  id mapping 유틸 개발

- domain 엔티티에는 JPA 처럼 id 를 매핑 해주는 코드가 없습니다.
- 따라서 기존 생성 메서드와 of 와 같은 id 메개인자를 추가한 생성 메서드를 둘 다 구현해야 합니다.
 - 위와 같은 방식도 도메인 계층에서 도메인 엔티티와 반환값으로 id가 매핑된 엔티티와 논리적인 동등성과 물리적인 동등성의 오차가 있을 것입니다.
- 위와 같은 문제로 reflection 을 사용한 id mapper 를 만들었고 나중에 ArchitRuleTest 를 통해서 reflection 에 의한 해당 컴포넌트의 보안 문제를 제한할 예정입니다

### 👍 고민사항

- 기존에 domain 계층과 infra 계층 간에 분리 때문에 domain 계층에서 entity 생성 및 수정을 분기하면서 코드를 작성했습니다

```java

// ex

repository.saveStore(store);

repository.updateStoreInfo(store);

repository.openStore(store);

```

- 이러한 entity 의 상태를 변경하는 모든 동작은 save 메서드로 뭉쳤고 다음과 같이 구현했습니다

```java

@Override
public Store save(Store store) {
var entity = StoreEntity.of(store);

storeJpaRepository.save(entity);

if (store.getId() == null) {
	idMapping(store, entity.getId());
}

return store;
}
```

- 위와 같이 구현 가능한 이유는 Jpa의 영속성 컨텍스트 및 SpringDataJpa 의 save 구현으로 가능합니다.
- 위와 같은 구현을 가져가면 인터페이스 단순화를 이룰 수 있다고 판단했습니다.



  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 엔티티 ID를 직접 설정하는 ID 매핑 유틸리티 추가
  - 매장 정보와 상세 이미지의 영속화·조회 지원 확대(상세 이미지 동기화 포함)

- Refactor
  - 매장 생성·수정·저장 흐름을 단일화해 일관성·안정성 개선
  - JPA 기반 저장소 전환 및 조회 로직 정비로 상세 이미지와 함께 조회 가능해짐
  - 매장 열기/닫기 상태 저장 방식 정비

- Tests
  - 저장/업데이트, 상세이미지 및 ID 매핑 관련 단위·통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->